### PR TITLE
Restore first-time setup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,8 +29,8 @@ export const App = () => {
 	}, []);
 	useEffect(() => {
 		settings.subscribe((settings) => {
-			if (settings !== undefined && settings.calibreLibraryPath?.length > 0) {
-				setLibraryPath(settings.calibreLibraryPath);
+			if (settings !== undefined) {
+				setLibraryPath(settings.calibreLibraryPath || null);
 				setIsLoading(false);
 			}
 		});

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -242,12 +242,6 @@ const SidebarPure = ({
 				<Button variant="outline" onPointerDown={switchLibraryHandler}>
 					Switch library
 				</Button>
-				<Button variant="transparent" justify="flex-start">
-					First-time setup
-				</Button>
-				<Button variant="transparent" justify="flex-start">
-					Configure library
-				</Button>
 			</Stack>
 			<Divider my="md" />
 			<Stack>


### PR DESCRIPTION
Not setting `isLoading` `false` when `settings.calibreLibraryPath` was empty meant that we never show a window on first-time-setup. Whoops!