### PR TITLE
Fade/hide read books

### DIFF
--- a/src-tauri/libcalibre/src/client.rs
+++ b/src-tauri/libcalibre/src/client.rs
@@ -152,6 +152,7 @@ impl CalibreClient {
             authors: created_author_list,
             files: created_files,
             book_description_html: None,
+            is_read: false,
         })
     }
 
@@ -224,11 +225,19 @@ impl CalibreClient {
             .list_all_by_book_id(book.id)
             .map_err(|_| ClientError::GenericError)?;
 
+        let is_read = self
+            .client_v2
+            .books()
+            .get_book_read_state_for_user(book.id)
+            .unwrap_or(Some(false))
+            .unwrap_or(false);
+
         Ok(BookWithAuthorsAndFiles {
             book,
             authors,
             files,
             book_description_html: book_desc,
+            is_read,
         })
     }
 

--- a/src-tauri/libcalibre/src/entities/book_aggregate.rs
+++ b/src-tauri/libcalibre/src/entities/book_aggregate.rs
@@ -7,6 +7,7 @@ pub struct BookWithAuthorsAndFiles {
     pub files: Vec<BookFile>,
     /// A partially HTML-formatted description of the book. User-editable.
     pub book_description_html: Option<String>,
+    pub is_read: bool,
 }
 
 impl BookWithAuthorsAndFiles {
@@ -15,12 +16,14 @@ impl BookWithAuthorsAndFiles {
         authors: Vec<Author>,
         files: Vec<BookFile>,
         description: Option<String>,
+        is_read: bool,
     ) -> Self {
         Self {
             book,
             authors,
             files,
             book_description_html: description,
+            is_read,
         }
     }
 }

--- a/src-tauri/src/book.rs
+++ b/src-tauri/src/book.rs
@@ -55,6 +55,8 @@ pub struct LibraryBook {
     pub identifier_list: Vec<Identifier>,
 
     pub description: Option<String>,
+
+    pub is_read: bool,
 }
 
 #[derive(Serialize, specta::Type, Deserialize, Clone)]

--- a/src-tauri/src/libs/calibre/book.rs
+++ b/src-tauri/src/libs/calibre/book.rs
@@ -17,6 +17,7 @@ fn to_library_book(
     file_list: Vec<libcalibre::BookFile>,
     identifer_list: Vec<Identifier>,
     description: Option<String>,
+    is_read: Option<bool>,
 ) -> LibraryBook {
     LibraryBook {
         title: book.title.clone(),
@@ -44,6 +45,8 @@ fn to_library_book(
         identifier_list: identifer_list.clone(),
 
         description,
+
+        is_read: is_read.unwrap_or(false),
     }
 }
 
@@ -95,6 +98,7 @@ pub fn list_all(library_root: String) -> Vec<LibraryBook> {
                         b.files.clone(),
                         identifer_list,
                         b.book_description_html.clone(),
+                        Some(b.is_read),
                     );
                     calibre_book.cover_image = book_cover_image(&library_root, &b.book);
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -82,7 +82,7 @@ file_contains_cover: boolean }
 export type ImportableBookType = "Epub" | "Pdf" | "Mobi" | "Text"
 export type ImportableFile = { path: string }
 export type LibraryAuthor = { id: string; name: string; sortable_name: string }
-export type LibraryBook = { id: string; uuid: string | null; title: string; author_list: LibraryAuthor[]; sortable_title: string | null; file_list: BookFile[]; cover_image: LocalOrRemoteUrl | null; identifier_list: Identifier[]; description: string | null }
+export type LibraryBook = { id: string; uuid: string | null; title: string; author_list: LibraryAuthor[]; sortable_title: string | null; file_list: BookFile[]; cover_image: LocalOrRemoteUrl | null; identifier_list: Identifier[]; description: string | null; is_read: boolean }
 export type LocalFile = { 
 /**
  * The absolute path to the file, including extension.

--- a/src/components/atoms/BookCover.tsx
+++ b/src/components/atoms/BookCover.tsx
@@ -1,52 +1,150 @@
 import { shortenToChars } from "$lib/domain/book";
 import { LibraryBook } from "@/bindings";
-import { Image, Text } from "@mantine/core";
-import { HTMLAttributes } from "react";
+import { AspectRatio, Overlay, Text, Transition } from "@mantine/core";
+import { HTMLAttributes, useState } from "react";
 import { formatAuthorList } from "@/lib/authors";
+
+type LibraryBookWithCoverImage = LibraryBook & {
+	cover_image: NonNullable<LibraryBook["cover_image"]>;
+};
+
+const BookCoverUsingImage = ({
+	book,
+	disableFade,
+	...props
+}: {
+	book: LibraryBookWithCoverImage;
+	disableFade: boolean;
+} & HTMLAttributes<HTMLDivElement>) => {
+	const [isHovering, setIsHovering] = useState(false);
+	return (
+		<div
+			style={{ height: "200px", width: "auto", position: "relative" }}
+			{...props}
+			onPointerOver={() => {
+				setIsHovering(true);
+			}}
+			onPointerLeave={() => {
+				setIsHovering(false);
+			}}
+		>
+			<img
+				src={book.cover_image.url}
+				alt={book.title}
+				style={{
+					height: "200px",
+					width: "auto",
+					objectFit: "contain",
+				}}
+			/>
+			<Transition
+				transition="fade"
+				duration={100}
+				mounted={book.is_read && !isHovering && !disableFade}
+			>
+				{(styles) => (
+					<Overlay
+						style={styles}
+						color="#12161a"
+						backgroundOpacity={0.8}
+						zIndex={2}
+					/>
+				)}
+			</Transition>
+		</div>
+	);
+};
+
+const BookCoverWithPlaceholder = ({
+	book,
+	disableFade,
+	...props
+}: {
+	book: LibraryBook;
+	disableFade: boolean;
+} & HTMLAttributes<HTMLDivElement>) => {
+	const [isHovering, setIsHovering] = useState(false);
+
+	return (
+		<AspectRatio
+			h={200}
+			w={150}
+			m="xs"
+			onPointerOver={() => {
+				setIsHovering(true);
+			}}
+			onPointerLeave={() => {
+				setIsHovering(false);
+			}}
+		>
+			<div
+				{...props}
+				style={{
+					width: "150px",
+					height: "200px",
+					background: "linear-gradient(#555, #111)",
+					backgroundColor: "#555",
+					padding: "0.5rem",
+				}}
+			>
+				<div
+					style={{
+						border: "2px solid #888",
+						height: "100%",
+						display: "flex",
+						flexDirection: "column",
+						alignContent: "center",
+						justifyContent: "space-between",
+						textAlign: "center",
+						padding: "0.5rem",
+					}}
+				>
+					<Text size="sm" c="white">
+						{shortenToChars(book.title, 50)}
+					</Text>
+					<Text size="sm" c="white">
+						{formatAuthorList(book.author_list)}
+					</Text>
+					<Transition
+						transition="fade"
+						duration={100}
+						mounted={book.is_read && !isHovering && !disableFade}
+					>
+						{(styles) => (
+							<Overlay
+								style={styles}
+								color="#12161a"
+								backgroundOpacity={0.8}
+								zIndex={2}
+							/>
+						)}
+					</Transition>
+				</div>
+			</div>
+		</AspectRatio>
+	);
+};
 
 export const BookCover = ({
 	book,
+	disableFade = false,
 	...props
-}: { book: LibraryBook } & HTMLAttributes<HTMLDivElement>) => {
+}: {
+	book: LibraryBook;
+	disableFade?: boolean;
+} & HTMLAttributes<HTMLDivElement>) => {
 	if (book.cover_image?.url !== undefined) {
 		return (
-			<Image
-				h={200}
-				w="auto"
-				fit="contain"
-				src={book.cover_image.url}
-				alt={book.title}
-				{...props}
-			/>
+			// @ts-expect-error `cover_image` obviously exists
+			<BookCoverUsingImage book={book} disableFade={disableFade} {...props} />
 		);
 	}
 
 	return (
-		<div
+		<BookCoverWithPlaceholder
+			book={book}
+			disableFade={disableFade}
 			{...props}
-			style={{
-				width: "150px",
-				height: "200px",
-				background: "linear-gradient(#555, #111)",
-				backgroundColor: "#555",
-				padding: "0.5rem",
-			}}
-		>
-			<div
-				style={{
-					border: "2px solid #888",
-					height: "100%",
-					display: "flex",
-					flexDirection: "column",
-					alignContent: "center",
-					justifyContent: "space-between",
-					textAlign: "center",
-					padding: "0.5rem",
-				}}
-			>
-				<Text size="sm">{shortenToChars(book.title, 50)}</Text>
-				<Text size="sm">{formatAuthorList(book.author_list)}</Text>
-			</div>
-		</div>
+		/>
 	);
 };

--- a/src/components/pages/Books.stories.tsx
+++ b/src/components/pages/Books.stories.tsx
@@ -36,6 +36,7 @@ const MOCK_BOOK: LibraryBook = {
 	cover_image: null,
 	title: "The Day I Bug'd",
 	sortable_title: "Day I Bug'd, The",
+	is_read: false,
 	identifier_list: [
 		{
 			id: 123,

--- a/src/components/pages/Books.tsx
+++ b/src/components/pages/Books.tsx
@@ -300,7 +300,7 @@ const BookDetails = ({ book }: { book: LibraryBook }) => {
 		<>
 			<Stack h={"100%"}>
 				<Group wrap={"nowrap"} align="flex-start">
-					<BookCover book={book} />
+					<BookCover book={book} disableFade />
 					<Stack ml={"sm"} align="flex-start" justify="flex-start">
 						<Text size="xl" fw={"700"}>
 							{book.title}


### PR DESCRIPTION
Citadel now fades the cover art of any book that is "read". You can also entirely hide read books.

If you already have a custom column from Calibre with the label 'read', this will be automatically used. Otherwise, a new column is created if it cannot be found.

"Has been read" states are not yet editable.

## Screenshots

Faded covers

<img width="1197" alt="Screenshot 2024-11-18 at 14 26 20" src="https://github.com/user-attachments/assets/4ce5eb27-b532-4687-8e2e-13ffdafd0197">

Entirely hide read books

<img width="1197" alt="Screenshot 2024-11-18 at 14 26 28" src="https://github.com/user-attachments/assets/33d5b160-a13d-4a57-9f73-691d120a03d2">
