### PR TITLE
Control book read status

### DIFF
--- a/src-tauri/libcalibre/src/client.rs
+++ b/src-tauri/libcalibre/src/client.rs
@@ -162,8 +162,16 @@ impl CalibreClient {
         updates: UpdateLibraryEntryDto,
     ) -> Result<crate::BookWithAuthorsAndFiles, Box<dyn std::error::Error>> {
         // Write new updates to book
+        let is_read = updates.book.is_read;
         let book_update = UpdateBookData::try_from(updates.book).unwrap();
         let _book = self.client_v2.books().update(book_id, book_update);
+
+        if is_read.is_some() {
+            let _set_book_result = self
+                .client_v2
+                .books()
+                .set_book_read_state(book_id, is_read.unwrap());
+        }
 
         match updates.author_id_list {
             Some(author_id_list) => {
@@ -228,7 +236,7 @@ impl CalibreClient {
         let is_read = self
             .client_v2
             .books()
-            .get_book_read_state_for_user(book.id)
+            .get_book_read_state(book.id)
             .unwrap_or(Some(false))
             .unwrap_or(false);
 

--- a/src-tauri/libcalibre/src/dtos/book.rs
+++ b/src-tauri/libcalibre/src/dtos/book.rs
@@ -21,6 +21,7 @@ pub struct UpdateBookDto {
     pub path: Option<String>,
     pub flags: Option<i32>,
     pub has_cover: Option<bool>,
+    pub is_read: Option<bool>,
 }
 
 impl UpdateBookDto {
@@ -34,6 +35,7 @@ impl UpdateBookDto {
             path: None,
             flags: None,
             has_cover: None,
+            is_read: None,
         }
     }
 }

--- a/src-tauri/src/libs/calibre/mod.rs
+++ b/src-tauri/src/libs/calibre/mod.rs
@@ -113,6 +113,7 @@ pub struct BookUpdate {
     pub title: Option<String>,
     pub timestamp: Option<NaiveDateTime>,
     pub publication_date: Option<NaiveDateTime>,
+    pub is_read: Option<bool>,
     // pub tags: Option<String>,
     // pub ext_id_list: Option<Vec<String>>,
 }
@@ -124,6 +125,7 @@ impl BookUpdate {
                 title: self.title.clone(),
                 timestamp: self.timestamp,
                 pubdate: self.publication_date,
+                is_read: self.is_read,
                 ..UpdateBookDto::default()
             },
             author_id_list: self.author_id_list.clone(),

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -52,7 +52,7 @@ return await TAURI_INVOKE("plugin:tauri-specta|init_client", { libraryPath });
 /** user-defined types **/
 
 export type BookFile = { Local: LocalFile } | { Remote: RemoteFile }
-export type BookUpdate = { author_id_list: string[] | null; title: string | null; timestamp: string | null; publication_date: string | null }
+export type BookUpdate = { author_id_list: string[] | null; title: string | null; timestamp: string | null; publication_date: string | null; is_read: boolean | null }
 export type CalibreClientConfig = { library_path: string }
 /**
  * Book identifiers, such as ISBN, DOI, Google Books ID, etc.


### PR DESCRIPTION
Adds a switch that allows you to toggle the read status of a book. As part of this, controls for saving & resetting book changes are moved to the top of the Edit Books page & only shown when the form is dirty.

<img width="2030" alt="Xnapper-2024-11-28-17 53 05" src="https://github.com/user-attachments/assets/cc8e85da-aadc-43da-8337-bf8716cb4d68">
