### PR TITLE
Move Edit & Read buttons up; make Sidebar links more obvious

### DIFF
--- a/src/components/icons/F7Pencil.tsx
+++ b/src/components/icons/F7Pencil.tsx
@@ -1,0 +1,20 @@
+import type { SVGProps } from "react";
+
+export function F7Pencil(props: SVGProps<SVGSVGElement>) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="1em"
+			height="1em"
+			viewBox="0 0 56 56"
+			{...props}
+		>
+			<title>Pencil</title>
+			{/* biome-ignore lint/style/useSelfClosingElements: It's an SVG */}
+			<path
+				fill="currentColor"
+				d="m43.293 16.926l2.367-2.32c1.196-1.196 1.242-2.485.188-3.563l-.797-.797c-1.055-1.055-2.344-.937-3.54.211l-2.367 2.344ZM15.66 44.488l25.57-25.547l-4.101-4.125l-25.594 25.57L9.31 45.59c-.211.562.375 1.219.937.984Z"
+			></path>
+		</svg>
+	);
+}

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -16,10 +16,10 @@ import {
 	setActiveLibrary,
 	settings,
 } from "@/stores/settings";
-import { Button, Divider, Modal, Stack, Title } from "@mantine/core";
+import { Button, Divider, Modal, NavLink, Stack, Title } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { Link } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { Link, useRouterState } from "@tanstack/react-router";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
 	AddBookForm,
 	title as addBookFormTitle,
@@ -29,6 +29,7 @@ import { SwitchLibraryForm } from "../molecules/SwitchLibraryForm";
 export const Sidebar = () => {
 	const { library, state, eventEmitter } = useLibrary();
 	const { set, subscribe } = useSettings();
+	const { location } = useRouterState();
 
 	const [metadata, setMetadata] = useState<ImportableBookMetadata | null>();
 	const [activeLibraryId, setActiveLibraryId] = useState<string>();
@@ -127,6 +128,15 @@ export const Sidebar = () => {
 		},
 		[closeSwitchLibraryModal, set],
 	);
+	const shelves = useMemo(() => {
+		return [
+			{
+				title: "All books",
+				path: "/",
+				isActive: () => location.pathname === "/",
+			},
+		];
+	}, [location]);
 
 	if (state !== LibraryState.ready) {
 		return null;
@@ -162,14 +172,7 @@ export const Sidebar = () => {
 			<SidebarPure
 				addBookHandler={selectAndEditBookFile}
 				switchLibraryHandler={switchLibrary}
-				shelves={[
-					{
-						title: "All Books",
-						LinkComponent: ({ children }: React.PropsWithChildren<unknown>) => (
-							<Link to={"/"}>{children}</Link>
-						),
-					},
-				]}
+				shelves={shelves}
 			/>
 		</>
 	);
@@ -249,7 +252,8 @@ interface SidebarPureProps {
 	switchLibraryHandler: () => void;
 	shelves: {
 		title: string;
-		LinkComponent: React.FunctionComponent<React.PropsWithChildren<unknown>>;
+		path: string;
+		isActive: () => boolean;
 	}[];
 }
 
@@ -271,13 +275,15 @@ const SidebarPure = ({
 			</Stack>
 			<Divider my="md" />
 			<Stack>
-				<Title order={5}>My shelves</Title>
-				{shelves.map(({ title, LinkComponent }) => (
-					<LinkComponent key={title}>
-						<Button variant="subtle" justify="flex-start" fullWidth>
-							{title}
-						</Button>
-					</LinkComponent>
+				<Title order={5}>Shelves</Title>
+				{shelves.map(({ title, path, isActive }) => (
+					<NavLink
+						key={path}
+						label={title}
+						component={Link}
+						to={path}
+						active={isActive()}
+					/>
 				))}
 			</Stack>
 		</>

--- a/src/components/pages/Books.tsx
+++ b/src/components/pages/Books.tsx
@@ -31,6 +31,7 @@ import { BookGrid } from "../molecules/BookGrid";
 import { BookTable } from "../molecules/BookTable";
 import { TablerCopy } from "../icons/TablerCopy";
 import { LibraryEventNames } from "@/lib/contexts/library/context";
+import { F7Pencil } from "../icons/F7Pencil";
 
 export const Books = () => {
 	const form = useForm<{
@@ -313,13 +314,34 @@ const BookDetails = ({ book }: { book: LibraryBook }) => {
 			<Stack h={"100%"}>
 				<Group wrap={"nowrap"} align="flex-start">
 					<BookCover book={book} disableFade />
-					<Stack ml={"sm"} align="flex-start" justify="flex-start">
-						<Text size="xl" fw={"700"}>
-							{book.title}
-						</Text>
-						<Text size="md">
-							{book.author_list.map((author) => author.name).join(", ")}
-						</Text>
+					<Stack justify="space-between" mih={"200px"}>
+						<Stack ml={"sm"} align="flex-start" justify="flex-start">
+							<Text size="xl" fw={"700"}>
+								{book.title}
+							</Text>
+							<Text size="md">
+								{book.author_list.map((author) => author.name).join(", ")}
+							</Text>
+						</Stack>
+						<Group justify="space-evenly" w={"100%"}>
+							<Button
+								variant="subtle"
+								onPointerDown={safeAsyncEventHandler(async () => {
+									const firstFile = book.file_list[0];
+									if (firstFile === undefined) return;
+
+									const isLocal = "Local" in firstFile;
+									if (!isLocal) return;
+
+									await open(firstFile.Local.path);
+								})}
+							>
+								Read
+							</Button>
+							<Link to={`/books/${book.id}`}>
+								<Button leftSection={<F7Pencil />}>Edit</Button>
+							</Link>
+						</Group>
 					</Stack>
 				</Group>
 				{book.description !== null && book.description.length > 0 && (
@@ -354,26 +376,6 @@ const BookDetails = ({ book }: { book: LibraryBook }) => {
 								</span>
 							))}
 					</p>
-				</Stack>
-				<Stack justify="flex-end" align="flex-end" style={{ flexGrow: 1 }}>
-					<Group>
-						<Button
-							onPointerDown={safeAsyncEventHandler(async () => {
-								const firstFile = book.file_list[0];
-								if (firstFile === undefined) return;
-
-								const isLocal = "Local" in firstFile;
-								if (!isLocal) return;
-
-								await open(firstFile.Local.path);
-							})}
-						>
-							Read
-						</Button>
-						<Link to={`/books/${book.id}`}>
-							<Button>Edit</Button>
-						</Link>
-					</Group>
 				</Stack>
 			</Stack>
 		</>


### PR DESCRIPTION
This makes it more obvious that the "All books" link goes home, and moves the Read and Edit buttons up the Book Details drawer to avoid having to scroll down all the time.

<img width="2040" alt="Xnapper-2024-11-28-18 46 39" src="https://github.com/user-attachments/assets/b2dfae32-73e3-46ad-9c58-dc2420aa339f">
<img width="2040" alt="Xnapper-2024-11-28-18 47 10" src="https://github.com/user-attachments/assets/a0684cb1-731b-48b4-9e27-3b18c39159e8">
