### PR TITLE
Drag & drop to import new books

### DIFF
--- a/src/lib/services/library/_internal/addBook.ts
+++ b/src/lib/services/library/_internal/addBook.ts
@@ -5,6 +5,27 @@ import { EventEmitter } from "@/lib/event";
 import { dialog } from "@tauri-apps/api";
 import type { Library } from "./_types";
 
+export const addBookByDragDrop = async (
+	library: Library,
+	paths: string[],
+): Promise<ImportableBookMetadata[]> => {
+	const importableMetadata = [];
+	for (const path of paths) {
+		const importableFile = await library.checkFileImportable(path);
+		if (!importableFile) {
+			continue;
+		}
+		const metadata = await library.getImportableFileMetadata(importableFile);
+		if (!metadata) {
+			continue;
+		}
+
+		importableMetadata.push(metadata);
+	}
+
+	return importableMetadata;
+};
+
 export const promptToAddBook = async (
 	library: Library,
 ): Promise<ImportableBookMetadata | undefined> => {


### PR DESCRIPTION
Dragging valid ebook files onto the Citadel window will now pop up the same import process as if you pressed "Add Book" and selected a path.

At this time, only one file can be imported at a time.