### PR TITLE
ci(release): fix tauri-action version resolution in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,8 +184,8 @@ jobs:
         with:
           tauriScript: bun tauri
           args: --config '{"bundle":{"createUpdaterArtifacts":true}}'
-          tagName: v__VERSION__
-          releaseName: Citadel v__VERSION__
+          tagName: v${{ steps.version.outputs.version }}
+          releaseName: Citadel v${{ steps.version.outputs.version }}
           releaseBody: |
             Automated ${{ steps.version.outputs.release_type }} release.
 


### PR DESCRIPTION
## Summary
- fix release workflow failure in `Build and publish release assets/release notes`
- replace `v__VERSION__` placeholders with the explicit computed output `${{ steps.version.outputs.version }}`

## Why
`tauri-apps/tauri-action@v0` failed with `Could not determine package name and version` while resolving placeholder values.

## Scope
- only updates `.github/workflows/release.yml`
