### PR TITLE
Import cover & ISBN from Hardcover

### DIFF
--- a/src-tauri/libcalibre/src/library.rs
+++ b/src-tauri/libcalibre/src/library.rs
@@ -344,10 +344,10 @@ impl Library {
 
     pub fn set_book_cover(
         &mut self,
-        _book_id: BookId,
-        _cover_data: Vec<u8>,
+        book_id: BookId,
+        cover_data: Vec<u8>,
     ) -> Result<(), CalibreError> {
-        todo!()
+        operations::assets::set_book_cover(&self.db_path.library_path, &mut self.conn, book_id, cover_data)
     }
 
     pub fn remove_book_cover(&mut self, _book_id: BookId) -> Result<(), CalibreError> {

--- a/src-tauri/libcalibre/src/library.rs
+++ b/src-tauri/libcalibre/src/library.rs
@@ -347,7 +347,12 @@ impl Library {
         book_id: BookId,
         cover_data: Vec<u8>,
     ) -> Result<(), CalibreError> {
-        operations::assets::set_book_cover(&self.db_path.library_path, &mut self.conn, book_id, cover_data)
+        operations::assets::set_book_cover(
+            &self.db_path.library_path,
+            &mut self.conn,
+            book_id,
+            cover_data,
+        )
     }
 
     pub fn remove_book_cover(&mut self, _book_id: BookId) -> Result<(), CalibreError> {

--- a/src-tauri/libcalibre/src/operations/assets.rs
+++ b/src-tauri/libcalibre/src/operations/assets.rs
@@ -4,7 +4,7 @@ use crate::{
     assets::{self, COVER_FILENAME},
     queries::{authors, book_descriptions, book_files, book_identifiers, books},
     types::BookId,
-    CalibreError,
+    CalibreError, UpdateBookData,
 };
 
 pub fn get_book_cover(
@@ -114,6 +114,27 @@ pub fn add_book_file_from_path(
             Err(e)
         }
     }
+}
+
+pub fn set_book_cover(
+    library_root: &String,
+    conn: &mut SqliteConnection,
+    book_id: BookId,
+    cover_data: Vec<u8>,
+) -> Result<(), CalibreError> {
+    conn.transaction::<(), CalibreError, _>(|conn| {
+        let book = books::get(conn, book_id)?.ok_or(CalibreError::BookNotFound(book_id))?;
+        let cover_path = assets::asset_path(library_root, &book.path, COVER_FILENAME);
+
+        assets::write(&cover_path, &cover_data)?;
+
+        let update = UpdateBookData {
+            has_cover: Some(true),
+            ..Default::default()
+        };
+        books::update(conn, book_id, update)?;
+        Ok(())
+    })
 }
 
 pub fn remove_book_file(

--- a/src-tauri/src/hardcover.rs
+++ b/src-tauri/src/hardcover.rs
@@ -214,7 +214,10 @@ fn normalize_isbn(raw: &str) -> Option<String> {
 }
 
 fn pick_preferred_isbn(isbns: &[String]) -> Option<String> {
-    let normalized: Vec<String> = isbns.iter().filter_map(|isbn| normalize_isbn(isbn)).collect();
+    let normalized: Vec<String> = isbns
+        .iter()
+        .filter_map(|isbn| normalize_isbn(isbn))
+        .collect();
     normalized
         .iter()
         .find(|isbn| isbn.len() == 13)
@@ -252,8 +255,8 @@ async fn fetch_hardcover_metadata_by_id_inner(
         .and_then(|v| v.as_array())
         .ok_or("No books data in response")?;
     let first = books.first().ok_or("No book found for Hardcover ID")?;
-    let doc: GqlBookDocument =
-        serde_json::from_value(first.clone()).map_err(|e| format!("Failed to parse book: {}", e))?;
+    let doc: GqlBookDocument = serde_json::from_value(first.clone())
+        .map_err(|e| format!("Failed to parse book: {}", e))?;
 
     Ok(HardcoverBookMetadata {
         title: doc.title.unwrap_or_default(),

--- a/src-tauri/src/hardcover.rs
+++ b/src-tauri/src/hardcover.rs
@@ -11,6 +11,7 @@ pub struct HardcoverBookMetadata {
     pub title: String,
     pub description: Option<String>,
     pub image_url: Option<String>,
+    pub isbn: Option<String>,
     pub release_year: Option<i32>,
     pub hardcover_id: Option<i32>,
     pub slug: Option<String>,
@@ -21,6 +22,7 @@ pub struct HardcoverSearchResult {
     pub title: String,
     pub description: Option<String>,
     pub image_url: Option<String>,
+    pub isbn: Option<String>,
     pub release_year: Option<i32>,
     pub hardcover_id: i32,
     pub slug: Option<String>,
@@ -63,6 +65,12 @@ impl<'de> Deserialize<'de> for FlexibleImage {
             serde_json::Value::Object(obj) => {
                 obj.get("url").and_then(|u| u.as_str()).map(String::from)
             }
+            serde_json::Value::Array(items) => items.iter().find_map(|item| {
+                item.as_object()
+                    .and_then(|obj| obj.get("url"))
+                    .and_then(|u| u.as_str())
+                    .map(String::from)
+            }),
             _ => None,
         };
         Ok(FlexibleImage(url))
@@ -85,6 +93,8 @@ struct GqlBookDocument {
     title: Option<String>,
     description: Option<String>,
     image: Option<FlexibleImage>,
+    #[serde(default)]
+    isbns: Vec<String>,
     release_year: Option<i32>,
     slug: Option<String>,
     #[serde(default)]
@@ -170,6 +180,90 @@ fn parse_search_data(data: &serde_json::Value) -> Result<GqlSearchData, String> 
     let search = data.get("search").ok_or("No search data in response")?;
     serde_json::from_value(search.clone())
         .map_err(|e| format!("Failed to parse search results: {}", e))
+}
+
+fn normalize_isbn(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let without_prefix = trimmed
+        .strip_prefix("ISBN:")
+        .or_else(|| trimmed.strip_prefix("isbn:"))
+        .unwrap_or(trimmed)
+        .trim();
+
+    let compact: String = without_prefix
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect();
+    if compact.is_empty() {
+        return None;
+    }
+
+    let upper = compact.to_uppercase();
+    let valid = upper.len() == 13 && upper.chars().all(|c| c.is_ascii_digit())
+        || (upper.len() == 10
+            && upper[..9].chars().all(|c| c.is_ascii_digit())
+            && upper[9..].chars().all(|c| c.is_ascii_digit() || c == 'X'));
+    if valid {
+        Some(upper)
+    } else {
+        None
+    }
+}
+
+fn pick_preferred_isbn(isbns: &[String]) -> Option<String> {
+    let normalized: Vec<String> = isbns.iter().filter_map(|isbn| normalize_isbn(isbn)).collect();
+    normalized
+        .iter()
+        .find(|isbn| isbn.len() == 13)
+        .cloned()
+        .or_else(|| normalized.into_iter().next())
+}
+
+async fn fetch_hardcover_metadata_by_id_inner(
+    api_key: &str,
+    hardcover_id: i32,
+) -> Result<HardcoverBookMetadata, String> {
+    let query = r#"
+        query BookById($hardcoverId: Int!) {
+            books(where: { id: { _eq: $hardcoverId } }, limit: 1) {
+                id
+                title
+                description
+                image
+                release_year
+                slug
+                isbns
+            }
+        }
+    "#;
+
+    let response = hardcover_request(api_key)
+        .json(&json!({ "query": query, "variables": { "hardcoverId": hardcover_id } }))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to connect to Hardcover API: {}", e))?;
+
+    let data = execute_graphql(response).await?;
+    let books = data
+        .get("books")
+        .and_then(|v| v.as_array())
+        .ok_or("No books data in response")?;
+    let first = books.first().ok_or("No book found for Hardcover ID")?;
+    let doc: GqlBookDocument =
+        serde_json::from_value(first.clone()).map_err(|e| format!("Failed to parse book: {}", e))?;
+
+    Ok(HardcoverBookMetadata {
+        title: doc.title.unwrap_or_default(),
+        description: doc.description,
+        image_url: doc.image.and_then(|i| i.0),
+        isbn: pick_preferred_isbn(&doc.isbns),
+        release_year: doc.release_year,
+        hardcover_id: doc.id.0,
+        slug: doc.slug,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -259,10 +353,28 @@ pub async fn fetch_hardcover_metadata_by_isbn(
         title: doc.title.clone().unwrap_or_default(),
         description: doc.description.clone(),
         image_url: doc.image.as_ref().and_then(|i| i.0.clone()),
+        isbn: pick_preferred_isbn(&doc.isbns).or_else(|| normalize_isbn(isbn)),
         release_year: doc.release_year,
         hardcover_id: doc.id.0,
         slug: doc.slug.clone(),
     })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn fetch_hardcover_metadata_by_book_id(
+    api_key: String,
+    hardcover_id: i32,
+) -> Result<HardcoverBookMetadata, String> {
+    let api_key = api_key.trim();
+    if api_key.is_empty() {
+        return Err("API key is empty".to_string());
+    }
+    if hardcover_id <= 0 {
+        return Err("Hardcover ID must be positive".to_string());
+    }
+
+    fetch_hardcover_metadata_by_id_inner(api_key, hardcover_id).await
 }
 
 #[tauri::command]
@@ -306,6 +418,7 @@ pub async fn search_hardcover_books(
                 title: doc.title.clone().unwrap_or_default(),
                 description: doc.description.clone(),
                 image_url: doc.image.as_ref().and_then(|i| i.0.clone()),
+                isbn: pick_preferred_isbn(&doc.isbns),
                 release_year: doc.release_year,
                 hardcover_id: doc
                     .id

--- a/src-tauri/src/libs/calibre/command.rs
+++ b/src-tauri/src/libs/calibre/command.rs
@@ -109,6 +109,43 @@ pub fn clb_cmd_delete_book_identifier(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn clb_cmd_set_book_cover_from_url(
+    state: tauri::State<'_, CitadelState>,
+    book_id: String,
+    image_url: String,
+) -> Result<(), String> {
+    let book_id_int = book_id.parse::<i32>().map_err(|e| e.to_string())?;
+    let image_url = image_url.trim();
+    if image_url.is_empty() {
+        return Err("Image URL is empty".to_string());
+    }
+
+    let response = reqwest::Client::new()
+        .get(image_url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to download cover image: {}", e))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Cover image request returned status {}",
+            response.status()
+        ));
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read cover image bytes: {}", e))?;
+
+    state.with_library(|lib| {
+        lib.set_book_cover(libcalibre::BookId::from(book_id_int), bytes.to_vec())
+            .map_err(|e| e.to_string())
+    })?
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn clb_cmd_update_author(
     state: tauri::State<CitadelState>,
     author_id: String,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,6 +33,7 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::command::clb_cmd_update_book,
         calibre::command::clb_cmd_upsert_book_identifier,
         calibre::command::clb_cmd_delete_book_identifier,
+        calibre::command::clb_cmd_set_book_cover_from_url,
         // Author query and manipulation commands
         calibre::query::clb_query_list_all_authors,
         calibre::command::clb_cmd_create_authors,
@@ -41,6 +42,7 @@ fn run_tauri_backend() -> std::io::Result<()> {
         // Hardcover integration commands
         hardcover::test_hardcover_connection,
         hardcover::fetch_hardcover_metadata_by_isbn,
+        hardcover::fetch_hardcover_metadata_by_book_id,
         hardcover::search_hardcover_books,
         app_updates::clb_cmd_check_for_updates,
         app_updates::clb_cmd_install_update_if_available,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -73,6 +73,14 @@ async clbCmdDeleteBookIdentifier(bookId: string, identifierId: number) : Promise
     else return { status: "error", error: e  as any };
 }
 },
+async clbCmdSetBookCoverFromUrl(bookId: string, imageUrl: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_cmd_set_book_cover_from_url", { bookId, imageUrl }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbQueryListAllAuthors() : Promise<Result<LibraryAuthor[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clb_query_list_all_authors") };
@@ -121,6 +129,14 @@ async fetchHardcoverMetadataByIsbn(apiKey: string, isbn: string) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
+async fetchHardcoverMetadataByBookId(apiKey: string, hardcoverId: number) : Promise<Result<HardcoverBookMetadata, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("fetch_hardcover_metadata_by_book_id", { apiKey, hardcoverId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async searchHardcoverBooks(apiKey: string, query: string) : Promise<Result<HardcoverSearchResult[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("search_hardcover_books", { apiKey, query }) };
@@ -162,8 +178,8 @@ export type BookFile = { Local: LocalFile } | { Remote: RemoteFile }
 export type BookUpdate = { author_id_list: string[] | null; title: string | null; timestamp: string | null; publication_date: string | null; is_read: boolean | null; description: string | null }
 export type CalibreClientConfig = { library_path: string }
 export type HardcoverApiStatus = { is_valid: boolean; message: string }
-export type HardcoverBookMetadata = { title: string; description: string | null; image_url: string | null; release_year: number | null; hardcover_id: number | null; slug: string | null }
-export type HardcoverSearchResult = { title: string; description: string | null; image_url: string | null; release_year: number | null; hardcover_id: number; slug: string | null; authors: string[] }
+export type HardcoverBookMetadata = { title: string; description: string | null; image_url: string | null; isbn: string | null; release_year: number | null; hardcover_id: number | null; slug: string | null }
+export type HardcoverSearchResult = { title: string; description: string | null; image_url: string | null; isbn: string | null; release_year: number | null; hardcover_id: number; slug: string | null; authors: string[] }
 /**
  * Book identifiers, such as ISBN, DOI, Google Books ID, etc.
  */

--- a/src/components/pages/EditBook.tsx
+++ b/src/components/pages/EditBook.tsx
@@ -65,15 +65,15 @@ export const BookPage = ({
 				</Text>{" "}
 				– {book.title}
 			</Title>
-				<EditBookForm
-					allAuthorList={allAuthorList}
-					onCreateAuthor={onCreateAuthor}
-					book={book}
-					onSave={onSave}
-					onDeleteIdentifier={onDeleteIdentifier}
-					onReloadBooks={onReloadBooks}
-					onUpsertIdentifier={onUpsertIdentifier}
-				/>
+			<EditBookForm
+				allAuthorList={allAuthorList}
+				onCreateAuthor={onCreateAuthor}
+				book={book}
+				onSave={onSave}
+				onDeleteIdentifier={onDeleteIdentifier}
+				onReloadBooks={onReloadBooks}
+				onUpsertIdentifier={onUpsertIdentifier}
+			/>
 		</Stack>
 	);
 };

--- a/src/components/pages/EditBook.tsx
+++ b/src/components/pages/EditBook.tsx
@@ -39,6 +39,7 @@ interface BookPageProps {
 	onCreateAuthor: (authorName: string) => Promise<void>;
 	onSave: (bookUpdate: BookUpdate) => Promise<void>;
 	onDeleteIdentifier: (bookId: string, identifierId: number) => Promise<void>;
+	onReloadBooks: () => Promise<void>;
 	onUpsertIdentifier: (
 		bookId: string,
 		identifierId: number | null,
@@ -54,6 +55,7 @@ export const BookPage = ({
 	onSave,
 	onUpsertIdentifier,
 	onDeleteIdentifier,
+	onReloadBooks,
 }: BookPageProps) => {
 	return (
 		<Stack h={"100%"}>
@@ -63,14 +65,15 @@ export const BookPage = ({
 				</Text>{" "}
 				– {book.title}
 			</Title>
-			<EditBookForm
-				allAuthorList={allAuthorList}
-				onCreateAuthor={onCreateAuthor}
-				book={book}
-				onSave={onSave}
-				onDeleteIdentifier={onDeleteIdentifier}
-				onUpsertIdentifier={onUpsertIdentifier}
-			/>
+				<EditBookForm
+					allAuthorList={allAuthorList}
+					onCreateAuthor={onCreateAuthor}
+					book={book}
+					onSave={onSave}
+					onDeleteIdentifier={onDeleteIdentifier}
+					onReloadBooks={onReloadBooks}
+					onUpsertIdentifier={onUpsertIdentifier}
+				/>
 		</Stack>
 	);
 };
@@ -128,12 +131,14 @@ const EditBookForm = ({
 	onSave,
 	onUpsertIdentifier,
 	onDeleteIdentifier,
+	onReloadBooks,
 }: {
 	allAuthorList: LibraryAuthor[];
 	book: LibraryBook;
 	onCreateAuthor: (name: string) => Promise<void>;
 	onSave: (update: BookUpdate) => Promise<void>;
 	onDeleteIdentifier: (bookId: string, identifierId: number) => Promise<void>;
+	onReloadBooks: () => Promise<void>;
 	onUpsertIdentifier: (
 		bookId: string,
 		identifierId: number | null,
@@ -159,6 +164,7 @@ const EditBookForm = ({
 		form,
 		onUpsertIdentifier,
 		onCreateAuthor: createAuthor,
+		onReloadBooks,
 	});
 
 	const editor = useEditor({

--- a/src/lib/hooks/use-hardcover-book-actions.ts
+++ b/src/lib/hooks/use-hardcover-book-actions.ts
@@ -17,6 +17,7 @@ interface UseHardcoverBookActionsParams {
 	book: LibraryBook;
 	allAuthorNames: string[];
 	form: FormSetter;
+	onReloadBooks: () => Promise<void>;
 	onUpsertIdentifier: (
 		bookId: string,
 		identifierId: number | null,
@@ -48,10 +49,26 @@ export interface UseHardcoverBookActionsReturn {
 	selectSearchResult: (result: HardcoverSearchResult) => Promise<void>;
 }
 
+const normalizeIsbn = (raw: string): string | undefined => {
+	const trimmed = raw.trim();
+	if (!trimmed) return undefined;
+
+	const withoutPrefix =
+		trimmed.toLowerCase().startsWith("isbn:")
+			? trimmed.slice("isbn:".length).trim()
+			: trimmed;
+
+	const compact = withoutPrefix.replace(/[^0-9xX]/g, "").toUpperCase();
+	if (/^\d{13}$/.test(compact)) return compact;
+	if (/^\d{9}[\dX]$/.test(compact)) return compact;
+	return undefined;
+};
+
 export const useHardcoverBookActions = ({
 	book,
 	allAuthorNames,
 	form,
+	onReloadBooks,
 	onUpsertIdentifier,
 	onCreateAuthor,
 }: UseHardcoverBookActionsParams): UseHardcoverBookActionsReturn => {
@@ -103,23 +120,39 @@ export const useHardcoverBookActions = ({
 				isbnIdentifier.value,
 			);
 
-			if (result.status === "ok") {
-				const metadata = result.data;
+				if (result.status === "ok") {
+					const metadata = result.data;
 
-				// Store Hardcover slug as identifier first (triggers book reload + form reset)
-				const slug = metadata.slug ?? metadata.hardcover_id?.toString();
-				if (slug) {
-					await onUpsertIdentifier(
+					if (metadata.image_url) {
+						await commands.clbCmdSetBookCoverFromUrl(book.id, metadata.image_url);
+						await onReloadBooks();
+					}
+
+					// Store Hardcover slug as identifier first (triggers book reload + form reset)
+					const slug = metadata.slug ?? metadata.hardcover_id?.toString();
+					if (slug) {
+						await onUpsertIdentifier(
 						book.id,
 						hardcoverIdIdentifier?.id ?? null,
 						"hardcover",
-						slug,
-					);
-				}
+							slug,
+						);
+					}
+					if (metadata.isbn) {
+						const normalizedIsbn = normalizeIsbn(metadata.isbn);
+						if (normalizedIsbn) {
+							await onUpsertIdentifier(
+								book.id,
+								isbnIdentifier?.id ?? null,
+								"isbn",
+								normalizedIsbn,
+							);
+						}
+					}
 
-				// Yield a microtask so React can flush the state update from
-				// onUpsertIdentifier (which triggers book reload → useEffect resets form).
-				// Not a hard guarantee, but sufficient in practice with React's sync rendering.
+					// Yield a microtask so React can flush the state update from
+					// onUpsertIdentifier (which triggers book reload → useEffect resets form).
+					// Not a hard guarantee, but sufficient in practice with React's sync rendering.
 				await new Promise((r) => setTimeout(r, 0));
 
 				// Now set form values (after the reset from the book reload)
@@ -232,6 +265,26 @@ export const useHardcoverBookActions = ({
 	};
 
 	const selectSearchResult = async (result: HardcoverSearchResult) => {
+		let resolvedMetadata:
+			| {
+					title: string;
+					description: string | null;
+					image_url: string | null;
+					isbn: string | null;
+					slug: string | null;
+			  }
+			| undefined;
+
+		if (hardcoverApiKey) {
+			const metadataById = await commands.fetchHardcoverMetadataByBookId(
+				hardcoverApiKey,
+				result.hardcover_id,
+			);
+			if (metadataById.status === "ok") {
+				resolvedMetadata = metadataById.data;
+			}
+		}
+
 		if (result.authors && result.authors.length > 0) {
 			for (const authorName of result.authors) {
 				if (!allAuthorNames.includes(authorName)) {
@@ -241,13 +294,31 @@ export const useHardcoverBookActions = ({
 		}
 
 		// Store Hardcover slug as identifier (triggers book reload + form reset)
-		const slug = result.slug ?? result.hardcover_id.toString();
+		const slug =
+			resolvedMetadata?.slug ?? result.slug ?? result.hardcover_id.toString();
 		await onUpsertIdentifier(
 			book.id,
 			hardcoverIdIdentifier?.id ?? null,
 			"hardcover",
 			slug,
 		);
+		const isbnValue = resolvedMetadata?.isbn ?? result.isbn;
+		if (isbnValue) {
+			const normalizedIsbn = normalizeIsbn(isbnValue);
+			if (normalizedIsbn) {
+				await onUpsertIdentifier(
+					book.id,
+					isbnIdentifier?.id ?? null,
+					"isbn",
+					normalizedIsbn,
+				);
+			}
+		}
+		const imageUrl = resolvedMetadata?.image_url ?? result.image_url;
+		if (imageUrl) {
+			await commands.clbCmdSetBookCoverFromUrl(book.id, imageUrl);
+			await onReloadBooks();
+		}
 
 		// Yield a microtask so React can flush the state update from
 		// onUpsertIdentifier (which triggers book reload → useEffect resets form).
@@ -255,11 +326,13 @@ export const useHardcoverBookActions = ({
 		await new Promise((r) => setTimeout(r, 0));
 
 		// Now set form values (after the reset from the book reload)
-		if (result.title) {
-			form.setFieldValue("title", result.title);
+		const selectedTitle = resolvedMetadata?.title ?? result.title;
+		const selectedDescription = resolvedMetadata?.description ?? result.description;
+		if (selectedTitle) {
+			form.setFieldValue("title", selectedTitle);
 		}
-		if (result.description) {
-			form.setFieldValue("description", result.description);
+		if (selectedDescription) {
+			form.setFieldValue("description", selectedDescription);
 		}
 		if (result.authors && result.authors.length > 0) {
 			form.setFieldValue("authorList", result.authors);

--- a/src/lib/hooks/use-hardcover-book-actions.ts
+++ b/src/lib/hooks/use-hardcover-book-actions.ts
@@ -7,7 +7,7 @@ import { useMemo, useState } from "react";
 export interface HardcoverMessage {
 	type: "success" | "error";
 	text: string;
-				}
+}
 
 interface FormSetter {
 	setFieldValue: (field: string, value: unknown) => void;
@@ -271,7 +271,7 @@ export const useHardcoverBookActions = ({
 					image_url: string | null;
 					isbn: string | null;
 					slug: string | null;
-			}
+			  }
 			| undefined;
 
 		if (hardcoverApiKey) {

--- a/src/lib/hooks/use-hardcover-book-actions.ts
+++ b/src/lib/hooks/use-hardcover-book-actions.ts
@@ -9,6 +9,14 @@ export interface HardcoverMessage {
 	text: string;
 }
 
+interface ResolvedHardcoverMetadata {
+	title: string;
+	description: string | null;
+	image_url: string | null;
+	isbn: string | null;
+	slug: string | null;
+}
+
 interface FormSetter {
 	setFieldValue: (field: string, value: unknown) => void;
 }
@@ -264,15 +272,7 @@ export const useHardcoverBookActions = ({
 	};
 
 	const selectSearchResult = async (result: HardcoverSearchResult) => {
-		let resolvedMetadata:
-			| {
-					title: string;
-					description: string | null;
-					image_url: string | null;
-					isbn: string | null;
-					slug: string | null;
-			  }
-			| undefined;
+		let resolvedMetadata: ResolvedHardcoverMetadata | undefined;
 
 		if (hardcoverApiKey) {
 			const metadataById = await commands.fetchHardcoverMetadataByBookId(

--- a/src/lib/hooks/use-hardcover-book-actions.ts
+++ b/src/lib/hooks/use-hardcover-book-actions.ts
@@ -7,7 +7,7 @@ import { useMemo, useState } from "react";
 export interface HardcoverMessage {
 	type: "success" | "error";
 	text: string;
-}
+				}
 
 interface FormSetter {
 	setFieldValue: (field: string, value: unknown) => void;
@@ -53,10 +53,9 @@ const normalizeIsbn = (raw: string): string | undefined => {
 	const trimmed = raw.trim();
 	if (!trimmed) return undefined;
 
-	const withoutPrefix =
-		trimmed.toLowerCase().startsWith("isbn:")
-			? trimmed.slice("isbn:".length).trim()
-			: trimmed;
+	const withoutPrefix = trimmed.toLowerCase().startsWith("isbn:")
+		? trimmed.slice("isbn:".length).trim()
+		: trimmed;
 
 	const compact = withoutPrefix.replace(/[^0-9xX]/g, "").toUpperCase();
 	if (/^\d{13}$/.test(compact)) return compact;
@@ -120,39 +119,39 @@ export const useHardcoverBookActions = ({
 				isbnIdentifier.value,
 			);
 
-				if (result.status === "ok") {
-					const metadata = result.data;
+			if (result.status === "ok") {
+				const metadata = result.data;
 
-					if (metadata.image_url) {
-						await commands.clbCmdSetBookCoverFromUrl(book.id, metadata.image_url);
-						await onReloadBooks();
-					}
+				if (metadata.image_url) {
+					await commands.clbCmdSetBookCoverFromUrl(book.id, metadata.image_url);
+					await onReloadBooks();
+				}
 
-					// Store Hardcover slug as identifier first (triggers book reload + form reset)
-					const slug = metadata.slug ?? metadata.hardcover_id?.toString();
-					if (slug) {
-						await onUpsertIdentifier(
+				// Store Hardcover slug as identifier first (triggers book reload + form reset)
+				const slug = metadata.slug ?? metadata.hardcover_id?.toString();
+				if (slug) {
+					await onUpsertIdentifier(
 						book.id,
 						hardcoverIdIdentifier?.id ?? null,
 						"hardcover",
-							slug,
+						slug,
+					);
+				}
+				if (metadata.isbn) {
+					const normalizedIsbn = normalizeIsbn(metadata.isbn);
+					if (normalizedIsbn) {
+						await onUpsertIdentifier(
+							book.id,
+							isbnIdentifier?.id ?? null,
+							"isbn",
+							normalizedIsbn,
 						);
 					}
-					if (metadata.isbn) {
-						const normalizedIsbn = normalizeIsbn(metadata.isbn);
-						if (normalizedIsbn) {
-							await onUpsertIdentifier(
-								book.id,
-								isbnIdentifier?.id ?? null,
-								"isbn",
-								normalizedIsbn,
-							);
-						}
-					}
+				}
 
-					// Yield a microtask so React can flush the state update from
-					// onUpsertIdentifier (which triggers book reload → useEffect resets form).
-					// Not a hard guarantee, but sufficient in practice with React's sync rendering.
+				// Yield a microtask so React can flush the state update from
+				// onUpsertIdentifier (which triggers book reload → useEffect resets form).
+				// Not a hard guarantee, but sufficient in practice with React's sync rendering.
 				await new Promise((r) => setTimeout(r, 0));
 
 				// Now set form values (after the reset from the book reload)
@@ -272,7 +271,7 @@ export const useHardcoverBookActions = ({
 					image_url: string | null;
 					isbn: string | null;
 					slug: string | null;
-			  }
+			}
 			| undefined;
 
 		if (hardcoverApiKey) {
@@ -327,7 +326,8 @@ export const useHardcoverBookActions = ({
 
 		// Now set form values (after the reset from the book reload)
 		const selectedTitle = resolvedMetadata?.title ?? result.title;
-		const selectedDescription = resolvedMetadata?.description ?? result.description;
+		const selectedDescription =
+			resolvedMetadata?.description ?? result.description;
 		if (selectedTitle) {
 			form.setFieldValue("title", selectedTitle);
 		}

--- a/src/routes/books.$bookId.tsx
+++ b/src/routes/books.$bookId.tsx
@@ -85,16 +85,16 @@ const EditBookRoute = () => {
 	}
 
 	return (
-			<BookPage
-				allAuthorList={allAuthorList}
-				book={book}
-				onCreateAuthor={onCreateAuthor}
-				onSave={onSave}
-				onUpsertIdentifier={onUpsertIdentifier}
-				onDeleteIdentifier={onDeleteIdentifier}
-				onReloadBooks={onReloadBooks}
-			/>
-		);
+		<BookPage
+			allAuthorList={allAuthorList}
+			book={book}
+			onCreateAuthor={onCreateAuthor}
+			onSave={onSave}
+			onUpsertIdentifier={onUpsertIdentifier}
+			onDeleteIdentifier={onDeleteIdentifier}
+			onReloadBooks={onReloadBooks}
+		/>
+	);
 };
 
 export const Route = createFileRoute("/books/$bookId")({

--- a/src/routes/books.$bookId.tsx
+++ b/src/routes/books.$bookId.tsx
@@ -71,6 +71,12 @@ const EditBookRoute = () => {
 		[actions],
 	);
 
+	const onReloadBooks = useCallback(async () => {
+		if (actions) {
+			await actions.loadBooks();
+		}
+	}, [actions]);
+
 	if (state !== LibraryState.ready) {
 		return <div>Loading...</div>;
 	}
@@ -79,15 +85,16 @@ const EditBookRoute = () => {
 	}
 
 	return (
-		<BookPage
-			allAuthorList={allAuthorList}
-			book={book}
-			onCreateAuthor={onCreateAuthor}
-			onSave={onSave}
-			onUpsertIdentifier={onUpsertIdentifier}
-			onDeleteIdentifier={onDeleteIdentifier}
-		/>
-	);
+			<BookPage
+				allAuthorList={allAuthorList}
+				book={book}
+				onCreateAuthor={onCreateAuthor}
+				onSave={onSave}
+				onUpsertIdentifier={onUpsertIdentifier}
+				onDeleteIdentifier={onDeleteIdentifier}
+				onReloadBooks={onReloadBooks}
+			/>
+		);
 };
 
 export const Route = createFileRoute("/books/$bookId")({


### PR DESCRIPTION
## Summary
- import cover image from Hardcover during metadata fetch/select and store as local Calibre cover
- import and normalize ISBN from Hardcover metadata/search results
- add backend Hardcover metadata apply command and wire UI flow to use it
- refresh books immediately so cover updates without requiring Save

https://github.com/user-attachments/assets/4eb028b1-c7ef-4e4d-b8c2-1885bb86d379

