### PR TITLE
feat: generic custom column support (CDL-1)

### DIFF
--- a/crates/libcalibre/src/custom_columns.rs
+++ b/crates/libcalibre/src/custom_columns.rs
@@ -1,0 +1,1077 @@
+//! Generic support for Calibre custom columns.
+//!
+//! Calibre stores user-defined metadata in "custom columns". Each column has a
+//! row in the `custom_columns` table describing it, plus one or two dynamic
+//! tables holding the per-book values:
+//!
+//! - Non-normalized datatypes (bool, int, float, datetime, comments,
+//!   composite) use a single `custom_column_{n}` table with `(book, value)`
+//!   rows.
+//! - Normalized datatypes (text, series, enumeration, rating) use a
+//!   `custom_column_{n}` value table plus a `books_custom_column_{n}_link`
+//!   link table.
+//!
+//! The DDL emitted by [`create`] matches Calibre's `create_custom_column`
+//! (src/calibre/db/backend.py) exactly, including its triggers and views.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Double, Integer, Text as SqlText};
+
+use crate::{types::BookId, CalibreError};
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/// The datatype of a Calibre custom column.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CustomColumnKind {
+    Bool,
+    Int,
+    Float,
+    Text,
+    Comments,
+    Datetime,
+    Enumeration,
+    Series,
+    Rating,
+    Composite,
+    /// A datatype this crate does not know about.
+    Other(String),
+}
+
+impl CustomColumnKind {
+    /// Parse a Calibre `custom_columns.datatype` string.
+    pub fn from_datatype(datatype: &str) -> Self {
+        match datatype {
+            "bool" => Self::Bool,
+            "int" => Self::Int,
+            "float" => Self::Float,
+            "text" => Self::Text,
+            "comments" => Self::Comments,
+            "datetime" => Self::Datetime,
+            "enumeration" => Self::Enumeration,
+            "series" => Self::Series,
+            "rating" => Self::Rating,
+            "composite" => Self::Composite,
+            other => Self::Other(other.to_string()),
+        }
+    }
+
+    /// The string Calibre stores in `custom_columns.datatype`.
+    pub fn datatype(&self) -> &str {
+        match self {
+            Self::Bool => "bool",
+            Self::Int => "int",
+            Self::Float => "float",
+            Self::Text => "text",
+            Self::Comments => "comments",
+            Self::Datetime => "datetime",
+            Self::Enumeration => "enumeration",
+            Self::Series => "series",
+            Self::Rating => "rating",
+            Self::Composite => "composite",
+            Self::Other(other) => other,
+        }
+    }
+
+    /// Whether Calibre stores this datatype in a value table + link table
+    /// (normalized) rather than one `(book, value)` table.
+    pub fn is_normalized(&self) -> bool {
+        matches!(
+            self,
+            Self::Text | Self::Series | Self::Enumeration | Self::Rating
+        )
+    }
+
+    /// Whether this crate supports reading and writing values of this kind.
+    pub fn supports_value_io(&self) -> bool {
+        matches!(
+            self,
+            Self::Bool
+                | Self::Int
+                | Self::Float
+                | Self::Text
+                | Self::Comments
+                | Self::Datetime
+                | Self::Enumeration
+        )
+    }
+
+    /// SQL type of the `value` column in the column's table, per Calibre.
+    fn sql_value_type(&self) -> Option<&'static str> {
+        match self {
+            Self::Rating | Self::Int => Some("INT"),
+            Self::Text | Self::Comments | Self::Series | Self::Composite | Self::Enumeration => {
+                Some("TEXT")
+            }
+            Self::Float => Some("REAL"),
+            Self::Datetime => Some("timestamp"),
+            Self::Bool => Some("BOOL"),
+            Self::Other(_) => None,
+        }
+    }
+}
+
+/// A custom column definition, as stored in Calibre's `custom_columns` table.
+#[derive(Clone, Debug)]
+pub struct CustomColumn {
+    pub id: i32,
+    /// Lookup name, e.g. `read` (Calibre exposes it as `#read`).
+    pub label: String,
+    /// Human-readable heading, e.g. `Read`.
+    pub name: String,
+    pub kind: CustomColumnKind,
+    pub is_multiple: bool,
+    pub editable: bool,
+    pub normalized: bool,
+    /// Allowed values for enumeration columns (parsed from `display` JSON).
+    /// Empty for other kinds.
+    pub enum_values: Vec<String>,
+    /// Raw `display` JSON.
+    pub display: String,
+}
+
+/// A value of a custom column for one book.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CustomValue {
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(String),
+    TextMultiple(Vec<String>),
+    Datetime(DateTime<Utc>),
+    Enumeration(String),
+}
+
+impl CustomValue {
+    fn type_name(&self) -> &'static str {
+        match self {
+            Self::Bool(_) => "Bool",
+            Self::Int(_) => "Int",
+            Self::Float(_) => "Float",
+            Self::Text(_) => "Text",
+            Self::TextMultiple(_) => "TextMultiple",
+            Self::Datetime(_) => "Datetime",
+            Self::Enumeration(_) => "Enumeration",
+        }
+    }
+}
+
+/// Description of a custom column to create.
+#[derive(Clone, Debug)]
+pub struct CustomColumnSpec {
+    /// Lookup name. Lowercased and validated against `^[a-z][a-z0-9_]*$`.
+    pub label: String,
+    /// Human-readable heading.
+    pub name: String,
+    pub kind: CustomColumnKind,
+    /// Only allowed for `CustomColumnKind::Text`.
+    pub is_multiple: bool,
+    /// Allowed values for enumeration columns. Ignored for other kinds
+    /// unless `display` is provided.
+    pub enum_values: Vec<String>,
+    /// Raw `display` JSON override. When `None`, a default is generated
+    /// (`{"enum_values": [...], "enum_colors": []}` for enumerations, `{}`
+    /// otherwise).
+    pub display: Option<String>,
+}
+
+// =============================================================================
+// Row mapping
+// =============================================================================
+
+#[derive(Queryable)]
+struct CustomColumnRow {
+    id: i32,
+    label: String,
+    name: String,
+    datatype: String,
+    #[allow(dead_code)]
+    mark_for_delete: bool,
+    editable: bool,
+    display: String,
+    is_multiple: bool,
+    normalized: bool,
+}
+
+impl CustomColumnRow {
+    fn into_column(self) -> CustomColumn {
+        let kind = CustomColumnKind::from_datatype(&self.datatype);
+        let enum_values = parse_enum_values(&self.display);
+        CustomColumn {
+            id: self.id,
+            label: self.label,
+            name: self.name,
+            kind,
+            is_multiple: self.is_multiple,
+            editable: self.editable,
+            normalized: self.normalized,
+            enum_values,
+            display: self.display,
+        }
+    }
+}
+
+fn parse_enum_values(display_json: &str) -> Vec<String> {
+    serde_json::from_str::<serde_json::Value>(display_json)
+        .ok()
+        .and_then(|value| value.get("enum_values").cloned())
+        .and_then(|values| serde_json::from_value::<Vec<String>>(values).ok())
+        .unwrap_or_default()
+}
+
+// =============================================================================
+// Column queries
+// =============================================================================
+
+/// All custom columns not marked for deletion, ordered by id.
+pub(crate) fn list(conn: &mut SqliteConnection) -> Result<Vec<CustomColumn>, CalibreError> {
+    use crate::schema::custom_columns::dsl::*;
+
+    custom_columns
+        .filter(mark_for_delete.eq(false))
+        .order(id.asc())
+        .load::<CustomColumnRow>(conn)
+        .map(|rows| rows.into_iter().map(CustomColumnRow::into_column).collect())
+        .map_err(CalibreError::from)
+}
+
+/// Fetch one custom column by id.
+pub(crate) fn get_column(
+    conn: &mut SqliteConnection,
+    column_id: i32,
+) -> Result<CustomColumn, CalibreError> {
+    use crate::schema::custom_columns::dsl::*;
+
+    custom_columns
+        .filter(id.eq(column_id))
+        .first::<CustomColumnRow>(conn)
+        .optional()
+        .map_err(CalibreError::from)?
+        .map(CustomColumnRow::into_column)
+        .ok_or(CalibreError::CustomColumnNotFound(column_id))
+}
+
+/// Find a custom column by its label and datatype.
+pub(crate) fn find_by_label_and_kind(
+    conn: &mut SqliteConnection,
+    column_label: &str,
+    kind: &CustomColumnKind,
+) -> Result<Option<CustomColumn>, CalibreError> {
+    use crate::schema::custom_columns::dsl::*;
+
+    custom_columns
+        .filter(label.eq(column_label))
+        .filter(datatype.eq(kind.datatype()))
+        .first::<CustomColumnRow>(conn)
+        .optional()
+        .map(|row| row.map(CustomColumnRow::into_column))
+        .map_err(CalibreError::from)
+}
+
+// =============================================================================
+// Column creation
+// =============================================================================
+
+fn is_valid_label(label: &str) -> bool {
+    let mut chars = label.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_lowercase() => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+/// Create a custom column: inserts the `custom_columns` row and creates the
+/// value/link tables, indexes, triggers, and (for normalized columns) views,
+/// exactly as Calibre's `create_custom_column` does.
+pub(crate) fn create(
+    conn: &mut SqliteConnection,
+    spec: &CustomColumnSpec,
+) -> Result<CustomColumn, CalibreError> {
+    use crate::schema::custom_columns::dsl::*;
+
+    let value_type = spec.kind.sql_value_type().ok_or_else(|| {
+        CalibreError::UnsupportedCustomColumn(format!(
+            "cannot create a custom column with unknown datatype '{}'",
+            spec.kind.datatype()
+        ))
+    })?;
+
+    let column_label = spec.label.to_lowercase();
+    if !is_valid_label(&column_label) {
+        return Err(CalibreError::InvalidCustomColumn(format!(
+            "invalid custom column label '{}': must match ^[a-z][a-z0-9_]*$",
+            spec.label
+        )));
+    }
+
+    if spec.is_multiple && spec.kind != CustomColumnKind::Text {
+        return Err(CalibreError::InvalidCustomColumn(format!(
+            "is_multiple is only supported for text columns, not '{}'",
+            spec.kind.datatype()
+        )));
+    }
+
+    let display_json = match &spec.display {
+        Some(json) => json.clone(),
+        None if spec.kind == CustomColumnKind::Enumeration => serde_json::json!({
+            "enum_values": spec.enum_values,
+            "enum_colors": [],
+        })
+        .to_string(),
+        None => "{}".to_string(),
+    };
+
+    let column_normalized = spec.kind.is_normalized();
+
+    let new_id = conn.transaction::<_, CalibreError, _>(|conn| {
+        let new_id = diesel::insert_into(custom_columns)
+            .values((
+                label.eq(&column_label),
+                name.eq(&spec.name),
+                datatype.eq(spec.kind.datatype()),
+                mark_for_delete.eq(false),
+                editable.eq(true),
+                is_multiple.eq(spec.is_multiple),
+                normalized.eq(column_normalized),
+                display.eq(&display_json),
+            ))
+            .returning(id)
+            .get_result::<i32>(conn)
+            .map_err(CalibreError::from)?;
+
+        let collate = if value_type == "TEXT" {
+            "COLLATE NOCASE"
+        } else {
+            ""
+        };
+        let ddl = if column_normalized {
+            normalized_table_ddl(new_id, value_type, collate, &spec.kind)
+        } else {
+            non_normalized_table_ddl(new_id, value_type, collate)
+        };
+        conn.batch_execute(&ddl).map_err(CalibreError::from)?;
+
+        Ok(new_id)
+    })?;
+
+    get_column(conn, new_id)
+}
+
+/// DDL for non-normalized datatypes (bool, int, float, datetime, comments,
+/// composite). Verbatim from Calibre's `create_custom_column`.
+fn non_normalized_table_ddl(n: i32, dt: &str, collate: &str) -> String {
+    format!(
+        r#"CREATE TABLE custom_column_{n}(
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    book  INTEGER,
+    value {dt} NOT NULL {collate},
+    UNIQUE(book));
+CREATE INDEX custom_column_{n}_idx ON custom_column_{n} (book);
+CREATE TRIGGER fkc_insert_custom_column_{n}
+        BEFORE INSERT ON custom_column_{n}
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+            END;
+        END;
+CREATE TRIGGER fkc_update_custom_column_{n}
+        BEFORE UPDATE OF book ON custom_column_{n}
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+            END;
+        END;
+"#
+    )
+}
+
+/// DDL for normalized datatypes (text, series, enumeration, rating).
+/// Verbatim from Calibre's `create_custom_column`, including the `UPDATE OF
+/// author` oddity in the `_b` trigger.
+fn normalized_table_ddl(n: i32, dt: &str, collate: &str, kind: &CustomColumnKind) -> String {
+    let s_index = if *kind == CustomColumnKind::Series {
+        "extra REAL,"
+    } else {
+        ""
+    };
+    format!(
+        r#"CREATE TABLE custom_column_{n}(
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    value {dt} NOT NULL {collate},
+    link TEXT NOT NULL DEFAULT "",
+    UNIQUE(value));
+CREATE INDEX custom_column_{n}_idx ON custom_column_{n} (value {collate});
+CREATE TABLE books_custom_column_{n}_link(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book INTEGER NOT NULL,
+    value INTEGER NOT NULL,
+    {s_index}
+    UNIQUE(book, value)
+    );
+CREATE INDEX books_custom_column_{n}_link_aidx ON books_custom_column_{n}_link (value);
+CREATE INDEX books_custom_column_{n}_link_bidx ON books_custom_column_{n}_link (book);
+CREATE TRIGGER fkc_update_books_custom_column_{n}_link_a
+        BEFORE UPDATE OF book ON books_custom_column_{n}_link
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+            END;
+        END;
+CREATE TRIGGER fkc_update_books_custom_column_{n}_link_b
+        BEFORE UPDATE OF author ON books_custom_column_{n}_link
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from custom_column_{n} WHERE id=NEW.value) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: value not in custom_column_{n}')
+            END;
+        END;
+CREATE TRIGGER fkc_insert_books_custom_column_{n}_link
+        BEFORE INSERT ON books_custom_column_{n}_link
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+                WHEN (SELECT id from custom_column_{n} WHERE id=NEW.value) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: value not in custom_column_{n}')
+            END;
+        END;
+CREATE TRIGGER fkc_delete_books_custom_column_{n}_link
+        AFTER DELETE ON custom_column_{n}
+        BEGIN
+            DELETE FROM books_custom_column_{n}_link WHERE value=OLD.id;
+        END;
+CREATE VIEW tag_browser_custom_column_{n} AS SELECT
+    id,
+    value,
+    (SELECT COUNT(id) FROM books_custom_column_{n}_link WHERE value=custom_column_{n}.id) count,
+    (SELECT AVG(r.rating)
+     FROM books_custom_column_{n}_link,
+          books_ratings_link as bl,
+          ratings as r
+     WHERE books_custom_column_{n}_link.value=custom_column_{n}.id and bl.book=books_custom_column_{n}_link.book and
+           r.id = bl.rating and r.rating <> 0) avg_rating,
+    value AS sort
+FROM custom_column_{n};
+CREATE VIEW tag_browser_filtered_custom_column_{n} AS SELECT
+    id,
+    value,
+    (SELECT COUNT(books_custom_column_{n}_link.id) FROM books_custom_column_{n}_link WHERE value=custom_column_{n}.id AND
+    books_list_filter(book)) count,
+    (SELECT AVG(r.rating)
+     FROM books_custom_column_{n}_link,
+          books_ratings_link as bl,
+          ratings as r
+     WHERE books_custom_column_{n}_link.value=custom_column_{n}.id AND bl.book=books_custom_column_{n}_link.book AND
+           r.id = bl.rating AND r.rating <> 0 AND
+           books_list_filter(bl.book)) avg_rating,
+    value AS sort
+FROM custom_column_{n};
+"#
+    )
+}
+
+// =============================================================================
+// Value reads
+// =============================================================================
+
+#[derive(QueryableByName)]
+struct IdRow {
+    #[diesel(sql_type = Integer)]
+    id: i32,
+}
+
+#[derive(QueryableByName)]
+struct I64ValueRow {
+    #[diesel(sql_type = BigInt)]
+    value: i64,
+}
+
+#[derive(QueryableByName)]
+struct F64ValueRow {
+    #[diesel(sql_type = Double)]
+    value: f64,
+}
+
+#[derive(QueryableByName)]
+struct TextValueRow {
+    #[diesel(sql_type = SqlText)]
+    value: String,
+}
+
+#[derive(QueryableByName)]
+struct BookI64Row {
+    #[diesel(sql_type = Integer)]
+    book: i32,
+    #[diesel(sql_type = BigInt)]
+    value: i64,
+}
+
+#[derive(QueryableByName)]
+struct BookF64Row {
+    #[diesel(sql_type = Integer)]
+    book: i32,
+    #[diesel(sql_type = Double)]
+    value: f64,
+}
+
+#[derive(QueryableByName)]
+struct BookTextRow {
+    #[diesel(sql_type = Integer)]
+    book: i32,
+    #[diesel(sql_type = SqlText)]
+    value: String,
+}
+
+fn unsupported(column: &CustomColumn) -> CalibreError {
+    CalibreError::UnsupportedCustomColumn(format!(
+        "values of datatype '{}' (column '{}') are not supported",
+        column.kind.datatype(),
+        column.label
+    ))
+}
+
+/// Read one book's value for a custom column. `None` means no value stored.
+pub(crate) fn get_value(
+    conn: &mut SqliteConnection,
+    column: &CustomColumn,
+    book_id: BookId,
+) -> Result<Option<CustomValue>, CalibreError> {
+    let n = column.id;
+    match &column.kind {
+        CustomColumnKind::Bool => {
+            Ok(get_non_normalized_i64(conn, n, book_id)?.map(|v| CustomValue::Bool(v != 0)))
+        }
+        CustomColumnKind::Int => {
+            Ok(get_non_normalized_i64(conn, n, book_id)?.map(CustomValue::Int))
+        }
+        CustomColumnKind::Float => {
+            Ok(get_non_normalized_f64(conn, n, book_id)?.map(CustomValue::Float))
+        }
+        CustomColumnKind::Comments => {
+            Ok(get_non_normalized_text(conn, n, book_id)?.map(CustomValue::Text))
+        }
+        CustomColumnKind::Datetime => match get_non_normalized_text(conn, n, book_id)? {
+            None => Ok(None),
+            Some(raw) => parse_calibre_datetime(&raw)
+                .map(|dt| Some(CustomValue::Datetime(dt)))
+                .ok_or_else(|| {
+                    CalibreError::InvalidCustomValue(format!(
+                        "could not parse datetime value '{raw}' in column '{}'",
+                        column.label
+                    ))
+                }),
+        },
+        CustomColumnKind::Text if column.is_multiple => {
+            let values = get_normalized_texts(conn, n, book_id)?;
+            if values.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(CustomValue::TextMultiple(values)))
+            }
+        }
+        CustomColumnKind::Text => Ok(get_normalized_texts(conn, n, book_id)?
+            .into_iter()
+            .next()
+            .map(CustomValue::Text)),
+        CustomColumnKind::Enumeration => Ok(get_normalized_texts(conn, n, book_id)?
+            .into_iter()
+            .next()
+            .map(CustomValue::Enumeration)),
+        _ => Err(unsupported(column)),
+    }
+}
+
+/// Read one column's values for many books at once. Books with no value are
+/// absent from the result.
+pub(crate) fn batch_get_values(
+    conn: &mut SqliteConnection,
+    column: &CustomColumn,
+    book_ids: &[BookId],
+) -> Result<HashMap<BookId, CustomValue>, CalibreError> {
+    if book_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let n = column.id;
+    // Interpolating IDs is safe: BookId wraps an i32.
+    let ids = book_ids
+        .iter()
+        .map(|book_id| book_id.as_i32().to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    match &column.kind {
+        CustomColumnKind::Bool | CustomColumnKind::Int => {
+            let rows: Vec<BookI64Row> = sql_query(format!(
+                "SELECT book, value FROM custom_column_{n} WHERE book IN ({ids})"
+            ))
+            .load(conn)
+            .map_err(CalibreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|row| {
+                    let value = if column.kind == CustomColumnKind::Bool {
+                        CustomValue::Bool(row.value != 0)
+                    } else {
+                        CustomValue::Int(row.value)
+                    };
+                    (BookId(row.book), value)
+                })
+                .collect())
+        }
+        CustomColumnKind::Float => {
+            let rows: Vec<BookF64Row> = sql_query(format!(
+                "SELECT book, value FROM custom_column_{n} WHERE book IN ({ids})"
+            ))
+            .load(conn)
+            .map_err(CalibreError::from)?;
+
+            Ok(rows
+                .into_iter()
+                .map(|row| (BookId(row.book), CustomValue::Float(row.value)))
+                .collect())
+        }
+        CustomColumnKind::Comments | CustomColumnKind::Datetime => {
+            let rows: Vec<BookTextRow> = sql_query(format!(
+                "SELECT book, value FROM custom_column_{n} WHERE book IN ({ids})"
+            ))
+            .load(conn)
+            .map_err(CalibreError::from)?;
+
+            let mut values = HashMap::new();
+            for row in rows {
+                let value = if column.kind == CustomColumnKind::Datetime {
+                    let parsed = parse_calibre_datetime(&row.value).ok_or_else(|| {
+                        CalibreError::InvalidCustomValue(format!(
+                            "could not parse datetime value '{}' in column '{}'",
+                            row.value, column.label
+                        ))
+                    })?;
+                    CustomValue::Datetime(parsed)
+                } else {
+                    CustomValue::Text(row.value)
+                };
+                values.insert(BookId(row.book), value);
+            }
+            Ok(values)
+        }
+        CustomColumnKind::Text | CustomColumnKind::Enumeration => {
+            let rows: Vec<BookTextRow> = sql_query(format!(
+                "SELECT l.book AS book, cc.value AS value
+                 FROM books_custom_column_{n}_link l
+                 INNER JOIN custom_column_{n} cc ON cc.id = l.value
+                 WHERE l.book IN ({ids})
+                 ORDER BY l.book, l.id"
+            ))
+            .load(conn)
+            .map_err(CalibreError::from)?;
+
+            if column.kind == CustomColumnKind::Enumeration {
+                Ok(rows
+                    .into_iter()
+                    .map(|row| (BookId(row.book), CustomValue::Enumeration(row.value)))
+                    .collect())
+            } else if column.is_multiple {
+                let mut grouped: HashMap<BookId, Vec<String>> = HashMap::new();
+                for row in rows {
+                    grouped.entry(BookId(row.book)).or_default().push(row.value);
+                }
+                Ok(grouped
+                    .into_iter()
+                    .map(|(book_id, values)| (book_id, CustomValue::TextMultiple(values)))
+                    .collect())
+            } else {
+                Ok(rows
+                    .into_iter()
+                    .map(|row| (BookId(row.book), CustomValue::Text(row.value)))
+                    .collect())
+            }
+        }
+        _ => Err(unsupported(column)),
+    }
+}
+
+fn get_non_normalized_i64(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+) -> Result<Option<i64>, CalibreError> {
+    sql_query(format!("SELECT value FROM custom_column_{n} WHERE book = ?"))
+        .bind::<Integer, _>(book_id.as_i32())
+        .get_result::<I64ValueRow>(conn)
+        .optional()
+        .map(|row| row.map(|r| r.value))
+        .map_err(CalibreError::from)
+}
+
+fn get_non_normalized_f64(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+) -> Result<Option<f64>, CalibreError> {
+    sql_query(format!("SELECT value FROM custom_column_{n} WHERE book = ?"))
+        .bind::<Integer, _>(book_id.as_i32())
+        .get_result::<F64ValueRow>(conn)
+        .optional()
+        .map(|row| row.map(|r| r.value))
+        .map_err(CalibreError::from)
+}
+
+fn get_non_normalized_text(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+) -> Result<Option<String>, CalibreError> {
+    sql_query(format!("SELECT value FROM custom_column_{n} WHERE book = ?"))
+        .bind::<Integer, _>(book_id.as_i32())
+        .get_result::<TextValueRow>(conn)
+        .optional()
+        .map(|row| row.map(|r| r.value))
+        .map_err(CalibreError::from)
+}
+
+fn get_normalized_texts(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+) -> Result<Vec<String>, CalibreError> {
+    sql_query(format!(
+        "SELECT cc.value AS value
+         FROM books_custom_column_{n}_link l
+         INNER JOIN custom_column_{n} cc ON cc.id = l.value
+         WHERE l.book = ?
+         ORDER BY l.id"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .load::<TextValueRow>(conn)
+    .map(|rows| rows.into_iter().map(|r| r.value).collect())
+    .map_err(CalibreError::from)
+}
+
+// =============================================================================
+// Value writes
+// =============================================================================
+
+/// Write (or clear, with `None`) one book's value for a custom column.
+///
+/// The value must match the column's datatype; mismatches return
+/// `CalibreError::InvalidCustomValue`. Enumeration values are validated
+/// against the column's `enum_values`; an empty enumeration string clears.
+pub(crate) fn set_value(
+    conn: &mut SqliteConnection,
+    column: &CustomColumn,
+    book_id: BookId,
+    value: Option<CustomValue>,
+) -> Result<(), CalibreError> {
+    if !column.kind.supports_value_io() {
+        return Err(unsupported(column));
+    }
+
+    let n = column.id;
+    let Some(value) = value else {
+        return clear_value(conn, column, book_id);
+    };
+
+    match (&column.kind, value) {
+        (CustomColumnKind::Bool, CustomValue::Bool(b)) => {
+            upsert_non_normalized_i64(conn, n, book_id, if b { 1 } else { 0 })
+        }
+        (CustomColumnKind::Int, CustomValue::Int(i)) => {
+            upsert_non_normalized_i64(conn, n, book_id, i)
+        }
+        (CustomColumnKind::Float, CustomValue::Float(f)) => {
+            upsert_non_normalized_f64(conn, n, book_id, f)
+        }
+        (CustomColumnKind::Comments, CustomValue::Text(s)) => {
+            upsert_non_normalized_text(conn, n, book_id, &s)
+        }
+        (CustomColumnKind::Datetime, CustomValue::Datetime(dt)) => {
+            upsert_non_normalized_text(conn, n, book_id, &format_calibre_datetime(&dt))
+        }
+        (CustomColumnKind::Text, CustomValue::Text(s)) if !column.is_multiple => {
+            set_normalized_values(conn, n, book_id, std::slice::from_ref(&s))
+        }
+        (CustomColumnKind::Text, CustomValue::TextMultiple(values)) if column.is_multiple => {
+            if values.is_empty() {
+                clear_value(conn, column, book_id)
+            } else {
+                set_normalized_values(conn, n, book_id, &values)
+            }
+        }
+        (CustomColumnKind::Enumeration, CustomValue::Enumeration(s)) => {
+            if s.is_empty() {
+                return clear_value(conn, column, book_id);
+            }
+            if !column.enum_values.contains(&s) {
+                return Err(CalibreError::InvalidCustomValue(format!(
+                    "'{s}' is not an allowed value for enumeration column '{}' (allowed: {:?})",
+                    column.label, column.enum_values
+                )));
+            }
+            set_normalized_values(conn, n, book_id, std::slice::from_ref(&s))
+        }
+        (_, other) => Err(CalibreError::InvalidCustomValue(format!(
+            "value of type {} does not match column '{}' with datatype '{}'{}",
+            other.type_name(),
+            column.label,
+            column.kind.datatype(),
+            if column.is_multiple {
+                " (is_multiple)"
+            } else {
+                ""
+            }
+        ))),
+    }
+}
+
+fn clear_value(
+    conn: &mut SqliteConnection,
+    column: &CustomColumn,
+    book_id: BookId,
+) -> Result<(), CalibreError> {
+    let n = column.id;
+    if matches!(
+        column.kind,
+        CustomColumnKind::Text | CustomColumnKind::Enumeration
+    ) {
+        conn.transaction::<_, CalibreError, _>(|conn| {
+            delete_links(conn, n, book_id)?;
+            prune_orphaned_values(conn, n)
+        })
+    } else {
+        sql_query(format!("DELETE FROM custom_column_{n} WHERE book = ?"))
+            .bind::<Integer, _>(book_id.as_i32())
+            .execute(conn)
+            .map(|_| ())
+            .map_err(CalibreError::from)
+    }
+}
+
+fn upsert_non_normalized_i64(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+    value: i64,
+) -> Result<(), CalibreError> {
+    sql_query(format!(
+        "INSERT OR REPLACE INTO custom_column_{n} (book, value) VALUES (?, ?)"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .bind::<BigInt, _>(value)
+    .execute(conn)
+    .map(|_| ())
+    .map_err(CalibreError::from)
+}
+
+fn upsert_non_normalized_f64(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+    value: f64,
+) -> Result<(), CalibreError> {
+    sql_query(format!(
+        "INSERT OR REPLACE INTO custom_column_{n} (book, value) VALUES (?, ?)"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .bind::<Double, _>(value)
+    .execute(conn)
+    .map(|_| ())
+    .map_err(CalibreError::from)
+}
+
+fn upsert_non_normalized_text(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+    value: &str,
+) -> Result<(), CalibreError> {
+    sql_query(format!(
+        "INSERT OR REPLACE INTO custom_column_{n} (book, value) VALUES (?, ?)"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .bind::<SqlText, _>(value)
+    .execute(conn)
+    .map(|_| ())
+    .map_err(CalibreError::from)
+}
+
+/// Replace the book's links for a normalized column with the given values,
+/// creating value rows as needed (case-insensitive match, mirroring the
+/// `COLLATE NOCASE` UNIQUE constraint) and pruning orphaned value rows.
+fn set_normalized_values(
+    conn: &mut SqliteConnection,
+    n: i32,
+    book_id: BookId,
+    values: &[String],
+) -> Result<(), CalibreError> {
+    conn.transaction::<_, CalibreError, _>(|conn| {
+        delete_links(conn, n, book_id)?;
+
+        for value in values {
+            let existing = sql_query(format!(
+                "SELECT id FROM custom_column_{n} WHERE value = ? COLLATE NOCASE LIMIT 1"
+            ))
+            .bind::<SqlText, _>(value)
+            .get_result::<IdRow>(conn)
+            .optional()
+            .map_err(CalibreError::from)?;
+
+            let value_id = match existing {
+                Some(row) => row.id,
+                // Older Calibre value tables lack the `link` column, so only
+                // mention `value` here.
+                None => sql_query(format!(
+                    "INSERT INTO custom_column_{n} (value) VALUES (?) RETURNING id"
+                ))
+                .bind::<SqlText, _>(value)
+                .get_result::<IdRow>(conn)
+                .map_err(CalibreError::from)?
+                .id,
+            };
+
+            // OR IGNORE: duplicate input values (incl. case-insensitive
+            // duplicates) map to the same value row.
+            sql_query(format!(
+                "INSERT OR IGNORE INTO books_custom_column_{n}_link (book, value) VALUES (?, ?)"
+            ))
+            .bind::<Integer, _>(book_id.as_i32())
+            .bind::<Integer, _>(value_id)
+            .execute(conn)
+            .map_err(CalibreError::from)?;
+        }
+
+        prune_orphaned_values(conn, n)
+    })
+}
+
+fn delete_links(conn: &mut SqliteConnection, n: i32, book_id: BookId) -> Result<(), CalibreError> {
+    sql_query(format!(
+        "DELETE FROM books_custom_column_{n}_link WHERE book = ?"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .execute(conn)
+    .map(|_| ())
+    .map_err(CalibreError::from)
+}
+
+fn prune_orphaned_values(conn: &mut SqliteConnection, n: i32) -> Result<(), CalibreError> {
+    sql_query(format!(
+        "DELETE FROM custom_column_{n} WHERE id NOT IN \
+         (SELECT DISTINCT value FROM books_custom_column_{n}_link)"
+    ))
+    .execute(conn)
+    .map(|_| ())
+    .map_err(CalibreError::from)
+}
+
+// =============================================================================
+// Datetime handling
+// =============================================================================
+
+/// Format a datetime the way Calibre stores them: `2024-01-15 10:30:00+00:00`.
+fn format_calibre_datetime(dt: &DateTime<Utc>) -> String {
+    dt.format("%Y-%m-%d %H:%M:%S%:z").to_string()
+}
+
+/// Parse the ISO-ish datetime strings Calibre writes. Lenient: accepts space
+/// or `T` separators, optional fractional seconds, optional UTC offset
+/// (naive values are assumed UTC), and bare dates.
+fn parse_calibre_datetime(raw: &str) -> Option<DateTime<Utc>> {
+    let raw = raw.trim();
+
+    if let Ok(dt) = DateTime::parse_from_rfc3339(raw) {
+        return Some(dt.with_timezone(&Utc));
+    }
+
+    for format in [
+        "%Y-%m-%d %H:%M:%S%.f%:z",
+        "%Y-%m-%dT%H:%M:%S%.f%:z",
+        "%Y-%m-%d %H:%M:%S%:z",
+        "%Y-%m-%d %H:%M:%S%z",
+    ] {
+        if let Ok(dt) = DateTime::parse_from_str(raw, format) {
+            return Some(dt.with_timezone(&Utc));
+        }
+    }
+
+    for format in [
+        "%Y-%m-%d %H:%M:%S%.f",
+        "%Y-%m-%dT%H:%M:%S%.f",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+    ] {
+        if let Ok(naive) = NaiveDateTime::parse_from_str(raw, format) {
+            return Some(Utc.from_utc_datetime(&naive));
+        }
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(raw, "%Y-%m-%d") {
+        return Some(Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0)?));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_calibre_datetime_variants() {
+        let expected = Utc.with_ymd_and_hms(2024, 1, 15, 10, 30, 0).unwrap();
+        for raw in [
+            "2024-01-15 10:30:00+00:00",
+            "2024-01-15T10:30:00+00:00",
+            "2024-01-15 10:30:00",
+            "2024-01-15T10:30:00",
+            "2024-01-15 11:30:00+01:00",
+        ] {
+            assert_eq!(parse_calibre_datetime(raw), Some(expected), "raw: {raw}");
+        }
+
+        assert_eq!(
+            parse_calibre_datetime("2024-01-15 10:30:00.123456+00:00"),
+            Some(
+                Utc.with_ymd_and_hms(2024, 1, 15, 10, 30, 0).unwrap()
+                    + chrono::Duration::microseconds(123456)
+            )
+        );
+
+        assert_eq!(
+            parse_calibre_datetime("2024-01-15"),
+            Some(Utc.with_ymd_and_hms(2024, 1, 15, 0, 0, 0).unwrap())
+        );
+
+        assert_eq!(parse_calibre_datetime("not a date"), None);
+    }
+
+    #[test]
+    fn formats_calibre_datetime() {
+        let dt = Utc.with_ymd_and_hms(2024, 1, 15, 10, 30, 0).unwrap();
+        assert_eq!(format_calibre_datetime(&dt), "2024-01-15 10:30:00+00:00");
+    }
+
+    #[test]
+    fn validates_labels() {
+        assert!(is_valid_label("read"));
+        assert!(is_valid_label("a1_b2"));
+        assert!(!is_valid_label(""));
+        assert!(!is_valid_label("1read"));
+        assert!(!is_valid_label("_read"));
+        assert!(!is_valid_label("Read"));
+        assert!(!is_valid_label("re-ad"));
+        assert!(!is_valid_label("re ad"));
+    }
+}

--- a/crates/libcalibre/src/custom_columns.rs
+++ b/crates/libcalibre/src/custom_columns.rs
@@ -708,12 +708,14 @@ fn get_non_normalized_i64(
     n: i32,
     book_id: BookId,
 ) -> Result<Option<i64>, CalibreError> {
-    sql_query(format!("SELECT value FROM custom_column_{n} WHERE book = ?"))
-        .bind::<Integer, _>(book_id.as_i32())
-        .get_result::<I64ValueRow>(conn)
-        .optional()
-        .map(|row| row.map(|r| r.value))
-        .map_err(CalibreError::from)
+    sql_query(format!(
+        "SELECT value FROM custom_column_{n} WHERE book = ?"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .get_result::<I64ValueRow>(conn)
+    .optional()
+    .map(|row| row.map(|r| r.value))
+    .map_err(CalibreError::from)
 }
 
 fn get_non_normalized_f64(
@@ -721,12 +723,14 @@ fn get_non_normalized_f64(
     n: i32,
     book_id: BookId,
 ) -> Result<Option<f64>, CalibreError> {
-    sql_query(format!("SELECT value FROM custom_column_{n} WHERE book = ?"))
-        .bind::<Integer, _>(book_id.as_i32())
-        .get_result::<F64ValueRow>(conn)
-        .optional()
-        .map(|row| row.map(|r| r.value))
-        .map_err(CalibreError::from)
+    sql_query(format!(
+        "SELECT value FROM custom_column_{n} WHERE book = ?"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .get_result::<F64ValueRow>(conn)
+    .optional()
+    .map(|row| row.map(|r| r.value))
+    .map_err(CalibreError::from)
 }
 
 fn get_non_normalized_text(
@@ -734,12 +738,14 @@ fn get_non_normalized_text(
     n: i32,
     book_id: BookId,
 ) -> Result<Option<String>, CalibreError> {
-    sql_query(format!("SELECT value FROM custom_column_{n} WHERE book = ?"))
-        .bind::<Integer, _>(book_id.as_i32())
-        .get_result::<TextValueRow>(conn)
-        .optional()
-        .map(|row| row.map(|r| r.value))
-        .map_err(CalibreError::from)
+    sql_query(format!(
+        "SELECT value FROM custom_column_{n} WHERE book = ?"
+    ))
+    .bind::<Integer, _>(book_id.as_i32())
+    .get_result::<TextValueRow>(conn)
+    .optional()
+    .map(|row| row.map(|r| r.value))
+    .map_err(CalibreError::from)
 }
 
 fn get_normalized_texts(
@@ -942,13 +948,15 @@ fn set_normalized_values(
                 Some(row) => row.id,
                 // Older Calibre value tables lack the `link` column, so only
                 // mention `value` here.
-                None => sql_query(format!(
-                    "INSERT INTO custom_column_{n} (value) VALUES (?) RETURNING id"
-                ))
-                .bind::<SqlText, _>(value)
-                .get_result::<IdRow>(conn)
-                .map_err(CalibreError::from)?
-                .id,
+                None => {
+                    sql_query(format!(
+                        "INSERT INTO custom_column_{n} (value) VALUES (?) RETURNING id"
+                    ))
+                    .bind::<SqlText, _>(value)
+                    .get_result::<IdRow>(conn)
+                    .map_err(CalibreError::from)?
+                    .id
+                }
             };
 
             // OR IGNORE: duplicate input values (incl. case-insensitive

--- a/crates/libcalibre/src/custom_columns.rs
+++ b/crates/libcalibre/src/custom_columns.rs
@@ -794,16 +794,26 @@ pub(crate) fn set_value(
         (CustomColumnKind::Float, CustomValue::Float(f)) => {
             upsert_non_normalized_f64(conn, n, book_id, f)
         }
+        // Calibre never stores empty text values: an empty string clears.
         (CustomColumnKind::Comments, CustomValue::Text(s)) => {
-            upsert_non_normalized_text(conn, n, book_id, &s)
+            if s.is_empty() {
+                clear_value(conn, column, book_id)
+            } else {
+                upsert_non_normalized_text(conn, n, book_id, &s)
+            }
         }
         (CustomColumnKind::Datetime, CustomValue::Datetime(dt)) => {
             upsert_non_normalized_text(conn, n, book_id, &format_calibre_datetime(&dt))
         }
         (CustomColumnKind::Text, CustomValue::Text(s)) if !column.is_multiple => {
-            set_normalized_values(conn, n, book_id, std::slice::from_ref(&s))
+            if s.is_empty() {
+                clear_value(conn, column, book_id)
+            } else {
+                set_normalized_values(conn, n, book_id, std::slice::from_ref(&s))
+            }
         }
         (CustomColumnKind::Text, CustomValue::TextMultiple(values)) if column.is_multiple => {
+            let values: Vec<String> = values.into_iter().filter(|v| !v.is_empty()).collect();
             if values.is_empty() {
                 clear_value(conn, column, book_id)
             } else {

--- a/crates/libcalibre/src/error.rs
+++ b/crates/libcalibre/src/error.rs
@@ -32,6 +32,25 @@ pub enum CalibreError {
     #[error("Author cannot be deleted; they have associated books")]
     AuthorHasAssociatedBooks(Vec<BookId>),
 
+    /// Custom column with given ID was not found.
+    #[error("Custom column not found: {0}")]
+    CustomColumnNotFound(i32),
+
+    /// Operation is not supported for the custom column's datatype
+    /// (e.g. reading/writing series, rating, or composite columns).
+    #[error("Unsupported custom column operation: {0}")]
+    UnsupportedCustomColumn(String),
+
+    /// Custom column definition is invalid (e.g. bad label, is_multiple on a
+    /// non-text column).
+    #[error("Invalid custom column: {0}")]
+    InvalidCustomColumn(String),
+
+    /// Custom column value is invalid (type mismatch, value not in an
+    /// enumeration's allowed values, or an unparseable stored value).
+    #[error("Invalid custom column value: {0}")]
+    InvalidCustomValue(String),
+
     #[error("Library not initialized")]
     LibraryNotInitialized,
 

--- a/crates/libcalibre/src/lib.rs
+++ b/crates/libcalibre/src/lib.rs
@@ -1,5 +1,6 @@
 mod assets;
 mod cover_image;
+mod custom_columns;
 mod entities;
 pub mod error;
 pub mod library;
@@ -14,6 +15,7 @@ pub mod types;
 pub mod util;
 
 // Re-export the main API types
+pub use custom_columns::{CustomColumn, CustomColumnKind, CustomColumnSpec, CustomValue};
 pub use error::CalibreError;
 pub use library::{
     Author as LibraryAuthor, AuthorAdd, AuthorUpdate, Book as LibraryBook, BookAdd, BookFileInfo,

--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -603,14 +603,10 @@ impl Library {
     // Read state (the `read` bool custom column)
     // =========================================================================
 
-    pub(crate) fn get_or_create_read_state_column(
-        &mut self,
-    ) -> Result<CustomColumn, CalibreError> {
-        if let Some(column) = custom_columns::find_by_label_and_kind(
-            &mut self.conn,
-            "read",
-            &CustomColumnKind::Bool,
-        )? {
+    pub(crate) fn get_or_create_read_state_column(&mut self) -> Result<CustomColumn, CalibreError> {
+        if let Some(column) =
+            custom_columns::find_by_label_and_kind(&mut self.conn, "read", &CustomColumnKind::Bool)?
+        {
             return Ok(column);
         }
 

--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -1,13 +1,12 @@
 use std::{collections::HashMap, path::Path, path::PathBuf};
 
 use chrono::{NaiveDate, NaiveDateTime};
-use diesel::{
-    prelude::*, sql_query, sql_types::Integer, QueryableByName, RunQueryDsl, SqliteConnection,
-};
+use diesel::{prelude::*, sql_query, RunQueryDsl, SqliteConnection};
 use sanitise_file_name::sanitise;
 
 use crate::{
     cover_image::cover_image_data_from_path,
+    custom_columns::{self, CustomColumn, CustomColumnKind, CustomColumnSpec, CustomValue},
     entities::book_file::NewBookFile,
     operations,
     persistence::establish_connection,
@@ -528,69 +527,110 @@ impl Library {
     }
 
     // =========================================================================
-    // Read state (custom column)
+    // Custom columns
     // =========================================================================
 
-    pub(crate) fn get_or_create_read_state_column(&mut self) -> Result<i32, CalibreError> {
-        use crate::schema::custom_columns::dsl::*;
-        use diesel::prelude::*;
+    /// All custom columns in the library, excluding columns marked for
+    /// deletion.
+    pub fn custom_columns(&mut self) -> Result<Vec<CustomColumn>, CalibreError> {
+        custom_columns::list(&mut self.conn)
+    }
 
-        let column_id_opt = custom_columns
-            .select(id)
-            .filter(label.eq("read"))
-            .filter(datatype.eq("bool"))
-            .first::<i32>(&mut self.conn)
-            .optional()
-            .map_err(CalibreError::from)?;
+    /// Create a custom column, including its value tables, indexes, triggers,
+    /// and views, exactly as Calibre would.
+    pub fn create_custom_column(
+        &mut self,
+        spec: CustomColumnSpec,
+    ) -> Result<CustomColumn, CalibreError> {
+        custom_columns::create(&mut self.conn, &spec)
+    }
 
-        match column_id_opt {
-            Some(cid) => Ok(cid),
-            None => {
-                let cid = diesel::insert_into(custom_columns)
-                    .values((
-                        label.eq("read"),
-                        name.eq("Read"),
-                        datatype.eq("bool"),
-                        mark_for_delete.eq(false),
-                        editable.eq(true),
-                        is_multiple.eq(false),
-                        normalized.eq(false),
-                        display.eq("{}"),
-                    ))
-                    .returning(id)
-                    .get_result::<i32>(&mut self.conn)
-                    .map_err(CalibreError::from)?;
+    /// One book's value for a custom column. `None` when no value is stored
+    /// (for bool columns this is Calibre's tri-state "unknown").
+    pub fn get_custom_value(
+        &mut self,
+        book_id: BookId,
+        column_id: i32,
+    ) -> Result<Option<CustomValue>, CalibreError> {
+        let column = custom_columns::get_column(&mut self.conn, column_id)?;
+        custom_columns::get_value(&mut self.conn, &column, book_id)
+    }
 
-                sql_query(format!(
-                    "CREATE TABLE custom_column_{cid} (id INTEGER PRIMARY KEY, book INTEGER NOT NULL UNIQUE, value INTEGER NOT NULL);"
-                ))
-                .execute(&mut self.conn)
-                .map_err(CalibreError::from)?;
-
-                Ok(cid)
+    /// All stored custom-column values for a book, keyed by column id.
+    /// Columns with unsupported datatypes (series, rating, composite, ...)
+    /// are skipped.
+    pub fn get_custom_values_for_book(
+        &mut self,
+        book_id: BookId,
+    ) -> Result<HashMap<i32, CustomValue>, CalibreError> {
+        let columns = custom_columns::list(&mut self.conn)?;
+        let mut values = HashMap::new();
+        for column in columns {
+            if !column.kind.supports_value_io() {
+                continue;
+            }
+            if let Some(value) = custom_columns::get_value(&mut self.conn, &column, book_id)? {
+                values.insert(column.id, value);
             }
         }
+        Ok(values)
+    }
+
+    /// Set (or clear, with `None`) one book's value for a custom column.
+    /// The value must match the column's datatype.
+    pub fn set_custom_value(
+        &mut self,
+        book_id: BookId,
+        column_id: i32,
+        value: Option<CustomValue>,
+    ) -> Result<(), CalibreError> {
+        let column = custom_columns::get_column(&mut self.conn, column_id)?;
+        custom_columns::set_value(&mut self.conn, &column, book_id, value)
+    }
+
+    /// One column's values for many books at once. Books with no stored
+    /// value are absent from the result.
+    pub fn batch_get_custom_values(
+        &mut self,
+        column_id: i32,
+        book_ids: &[BookId],
+    ) -> Result<HashMap<BookId, CustomValue>, CalibreError> {
+        let column = custom_columns::get_column(&mut self.conn, column_id)?;
+        custom_columns::batch_get_values(&mut self.conn, &column, book_ids)
+    }
+
+    // =========================================================================
+    // Read state (the `read` bool custom column)
+    // =========================================================================
+
+    pub(crate) fn get_or_create_read_state_column(
+        &mut self,
+    ) -> Result<CustomColumn, CalibreError> {
+        if let Some(column) = custom_columns::find_by_label_and_kind(
+            &mut self.conn,
+            "read",
+            &CustomColumnKind::Bool,
+        )? {
+            return Ok(column);
+        }
+
+        custom_columns::create(
+            &mut self.conn,
+            &CustomColumnSpec {
+                label: "read".to_string(),
+                name: "Read".to_string(),
+                kind: CustomColumnKind::Bool,
+                is_multiple: false,
+                enum_values: vec![],
+                display: None,
+            },
+        )
     }
 
     pub fn get_book_read_state(&mut self, book_id: BookId) -> Result<bool, CalibreError> {
-        let col_id = self.get_or_create_read_state_column()?;
-
-        #[derive(QueryableByName)]
-        struct CustomValue {
-            #[diesel(sql_type = Integer)]
-            value: i32,
-        }
-
-        let result = sql_query(format!(
-            "SELECT value FROM custom_column_{col_id} WHERE book = ?"
-        ))
-        .bind::<Integer, _>(book_id.as_i32())
-        .get_result::<CustomValue>(&mut self.conn);
-
-        match result {
-            Ok(v) => Ok(v.value == 1),
-            Err(_) => Ok(false),
-        }
+        let column = self.get_or_create_read_state_column()?;
+        let value = custom_columns::get_value(&mut self.conn, &column, book_id)?;
+        Ok(matches!(value, Some(CustomValue::Bool(true))))
     }
 
     pub fn set_book_read_state(
@@ -598,17 +638,13 @@ impl Library {
         book_id: BookId,
         is_read: bool,
     ) -> Result<(), CalibreError> {
-        let col_id = self.get_or_create_read_state_column()?;
-        let value = if is_read { 1 } else { 0 };
-
-        sql_query(format!(
-            "INSERT OR REPLACE INTO custom_column_{col_id} (book, value) VALUES (?, ?)"
-        ))
-        .bind::<Integer, _>(book_id.as_i32())
-        .bind::<Integer, _>(value)
-        .execute(&mut self.conn)
-        .map(|_| ())
-        .map_err(CalibreError::from)
+        let column = self.get_or_create_read_state_column()?;
+        custom_columns::set_value(
+            &mut self.conn,
+            &column,
+            book_id,
+            Some(CustomValue::Bool(is_read)),
+        )
     }
 
     pub fn batch_get_read_states(
@@ -619,31 +655,12 @@ impl Library {
             return Ok(HashMap::new());
         }
 
-        let col_id = self.get_or_create_read_state_column()?;
+        let column = self.get_or_create_read_state_column()?;
+        let values = custom_columns::batch_get_values(&mut self.conn, &column, book_ids)?;
 
-        #[derive(QueryableByName)]
-        struct BookReadState {
-            #[diesel(sql_type = Integer)]
-            book: i32,
-            #[diesel(sql_type = Integer)]
-            value: i32,
-        }
-
-        let book_ids_str = book_ids
-            .iter()
-            .map(|id| id.as_i32().to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-
-        let results: Vec<BookReadState> = sql_query(format!(
-            "SELECT book, value FROM custom_column_{col_id} WHERE book IN ({book_ids_str})"
-        ))
-        .load(&mut self.conn)
-        .map_err(CalibreError::from)?;
-
-        Ok(results
+        Ok(values
             .into_iter()
-            .map(|r| (BookId(r.book), r.value == 1))
+            .map(|(book_id, value)| (book_id, matches!(value, CustomValue::Bool(true))))
             .collect())
     }
 

--- a/crates/libcalibre/tests/custom_columns_test.rs
+++ b/crates/libcalibre/tests/custom_columns_test.rs
@@ -274,6 +274,172 @@ fn test_batch_get_custom_values() {
 }
 
 #[test]
+fn test_batch_get_custom_values_normalized_kinds() {
+    let (_temp, mut lib) = setup_with_library();
+    let book1 = add_book(&mut lib);
+    let book2 = add_book(&mut lib);
+    let book3 = add_book(&mut lib); // never gets any value
+
+    let mood = lib
+        .create_custom_column(spec("mood", CustomColumnKind::Text))
+        .unwrap();
+    let genres = lib
+        .create_custom_column(CustomColumnSpec {
+            is_multiple: true,
+            ..spec("genres", CustomColumnKind::Text)
+        })
+        .unwrap();
+    let status = lib
+        .create_custom_column(CustomColumnSpec {
+            enum_values: vec!["reading".to_string(), "read".to_string()],
+            ..spec("status", CustomColumnKind::Enumeration)
+        })
+        .unwrap();
+
+    // Single-value text
+    lib.set_custom_value(book1, mood.id, Some(CustomValue::Text("cozy".to_string())))
+        .unwrap();
+    lib.set_custom_value(book2, mood.id, Some(CustomValue::Text("grim".to_string())))
+        .unwrap();
+
+    // Multiple text (grouping): two values for book1, one for book2
+    lib.set_custom_value(
+        book1,
+        genres.id,
+        Some(CustomValue::TextMultiple(vec![
+            "fantasy".to_string(),
+            "epic".to_string(),
+        ])),
+    )
+    .unwrap();
+    lib.set_custom_value(
+        book2,
+        genres.id,
+        Some(CustomValue::TextMultiple(vec!["noir".to_string()])),
+    )
+    .unwrap();
+
+    // Enumeration
+    lib.set_custom_value(
+        book1,
+        status.id,
+        Some(CustomValue::Enumeration("reading".to_string())),
+    )
+    .unwrap();
+    lib.set_custom_value(
+        book2,
+        status.id,
+        Some(CustomValue::Enumeration("read".to_string())),
+    )
+    .unwrap();
+
+    let books = [book1, book2, book3];
+
+    let moods = lib.batch_get_custom_values(mood.id, &books).unwrap();
+    assert_eq!(moods.len(), 2);
+    assert_eq!(
+        moods.get(&book1),
+        Some(&CustomValue::Text("cozy".to_string()))
+    );
+    assert_eq!(
+        moods.get(&book2),
+        Some(&CustomValue::Text("grim".to_string()))
+    );
+    assert_eq!(moods.get(&book3), None);
+
+    let genre_values = lib.batch_get_custom_values(genres.id, &books).unwrap();
+    assert_eq!(genre_values.len(), 2);
+    let Some(CustomValue::TextMultiple(mut book1_genres)) = genre_values.get(&book1).cloned()
+    else {
+        panic!("expected TextMultiple for book1");
+    };
+    book1_genres.sort();
+    assert_eq!(
+        book1_genres,
+        vec!["epic".to_string(), "fantasy".to_string()]
+    );
+    assert_eq!(
+        genre_values.get(&book2),
+        Some(&CustomValue::TextMultiple(vec!["noir".to_string()]))
+    );
+    assert_eq!(genre_values.get(&book3), None);
+
+    let statuses = lib.batch_get_custom_values(status.id, &books).unwrap();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(
+        statuses.get(&book1),
+        Some(&CustomValue::Enumeration("reading".to_string()))
+    );
+    assert_eq!(
+        statuses.get(&book2),
+        Some(&CustomValue::Enumeration("read".to_string()))
+    );
+    assert_eq!(statuses.get(&book3), None);
+}
+
+#[test]
+fn test_empty_text_values_clear() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+
+    // Single-value text: empty string clears
+    let mood = lib
+        .create_custom_column(spec("mood", CustomColumnKind::Text))
+        .unwrap();
+    lib.set_custom_value(book, mood.id, Some(CustomValue::Text("cozy".to_string())))
+        .unwrap();
+    lib.set_custom_value(book, mood.id, Some(CustomValue::Text(String::new())))
+        .unwrap();
+    assert_eq!(lib.get_custom_value(book, mood.id).unwrap(), None);
+
+    // Comments: empty string clears
+    let notes = lib
+        .create_custom_column(spec("notes", CustomColumnKind::Comments))
+        .unwrap();
+    lib.set_custom_value(book, notes.id, Some(CustomValue::Text("x".to_string())))
+        .unwrap();
+    lib.set_custom_value(book, notes.id, Some(CustomValue::Text(String::new())))
+        .unwrap();
+    assert_eq!(lib.get_custom_value(book, notes.id).unwrap(), None);
+
+    // Multiple text: empty entries are filtered out before writing
+    let genres = lib
+        .create_custom_column(CustomColumnSpec {
+            is_multiple: true,
+            ..spec("genres", CustomColumnKind::Text)
+        })
+        .unwrap();
+    lib.set_custom_value(
+        book,
+        genres.id,
+        Some(CustomValue::TextMultiple(vec![
+            "fantasy".to_string(),
+            String::new(),
+            "epic".to_string(),
+        ])),
+    )
+    .unwrap();
+    let Some(CustomValue::TextMultiple(mut values)) = lib.get_custom_value(book, genres.id).unwrap()
+    else {
+        panic!("expected TextMultiple");
+    };
+    values.sort();
+    assert_eq!(values, vec!["epic".to_string(), "fantasy".to_string()]);
+
+    // All entries empty: clears
+    lib.set_custom_value(
+        book,
+        genres.id,
+        Some(CustomValue::TextMultiple(vec![
+            String::new(),
+            String::new(),
+        ])),
+    )
+    .unwrap();
+    assert_eq!(lib.get_custom_value(book, genres.id).unwrap(), None);
+}
+
+#[test]
 fn test_get_custom_values_for_book_skips_unsupported() {
     let (_temp, mut lib) = setup_with_library();
     let book = add_book(&mut lib);

--- a/crates/libcalibre/tests/custom_columns_test.rs
+++ b/crates/libcalibre/tests/custom_columns_test.rs
@@ -1,0 +1,874 @@
+// Tests for the generic custom-column API.
+mod common;
+
+use chrono::{TimeZone, Utc};
+use common::{setup_with_library, standard_test_book};
+use libcalibre::{
+    BookId, CalibreError, CustomColumnKind, CustomColumnSpec, CustomValue, Library,
+};
+
+fn spec(label: &str, kind: CustomColumnKind) -> CustomColumnSpec {
+    CustomColumnSpec {
+        label: label.to_string(),
+        name: label.to_string(),
+        kind,
+        is_multiple: false,
+        enum_values: vec![],
+        display: None,
+    }
+}
+
+fn add_book(lib: &mut Library) -> BookId {
+    lib.add_book(standard_test_book()).unwrap().id
+}
+
+/// Open a second, raw connection to the library's metadata.db.
+fn raw_conn(lib: &Library) -> rusqlite::Connection {
+    rusqlite::Connection::open(lib.database_path()).unwrap()
+}
+
+// =============================================================================
+// 1. Round-trips for every supported kind
+// =============================================================================
+
+#[test]
+fn test_bool_round_trip_and_clear() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("finished", CustomColumnKind::Bool))
+        .unwrap();
+
+    // No row yet: tri-state "unknown"
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+
+    lib.set_custom_value(book, col.id, Some(CustomValue::Bool(true)))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Bool(true))
+    );
+
+    lib.set_custom_value(book, col.id, Some(CustomValue::Bool(false)))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Bool(false))
+    );
+
+    // Clear back to unknown
+    lib.set_custom_value(book, col.id, None).unwrap();
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+}
+
+#[test]
+fn test_int_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("pages", CustomColumnKind::Int))
+        .unwrap();
+
+    lib.set_custom_value(book, col.id, Some(CustomValue::Int(417)))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Int(417))
+    );
+
+    lib.set_custom_value(book, col.id, None).unwrap();
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+}
+
+#[test]
+fn test_float_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("price", CustomColumnKind::Float))
+        .unwrap();
+
+    lib.set_custom_value(book, col.id, Some(CustomValue::Float(12.5)))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Float(12.5))
+    );
+}
+
+#[test]
+fn test_text_single_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("mood", CustomColumnKind::Text))
+        .unwrap();
+    assert!(col.normalized);
+
+    lib.set_custom_value(book, col.id, Some(CustomValue::Text("cozy".to_string())))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Text("cozy".to_string()))
+    );
+
+    // Replace
+    lib.set_custom_value(book, col.id, Some(CustomValue::Text("grim".to_string())))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Text("grim".to_string()))
+    );
+
+    // Clear
+    lib.set_custom_value(book, col.id, None).unwrap();
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+}
+
+#[test]
+fn test_text_multiple_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(CustomColumnSpec {
+            is_multiple: true,
+            ..spec("genres", CustomColumnKind::Text)
+        })
+        .unwrap();
+    assert!(col.is_multiple);
+
+    lib.set_custom_value(
+        book,
+        col.id,
+        Some(CustomValue::TextMultiple(vec![
+            "fantasy".to_string(),
+            "epic".to_string(),
+        ])),
+    )
+    .unwrap();
+
+    let Some(CustomValue::TextMultiple(mut values)) = lib.get_custom_value(book, col.id).unwrap()
+    else {
+        panic!("expected TextMultiple");
+    };
+    values.sort();
+    assert_eq!(values, vec!["epic".to_string(), "fantasy".to_string()]);
+
+    // Empty list clears
+    lib.set_custom_value(book, col.id, Some(CustomValue::TextMultiple(vec![])))
+        .unwrap();
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+}
+
+#[test]
+fn test_comments_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("notes", CustomColumnKind::Comments))
+        .unwrap();
+    assert!(!col.normalized);
+
+    lib.set_custom_value(
+        book,
+        col.id,
+        Some(CustomValue::Text("<p>Loved it</p>".to_string())),
+    )
+    .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Text("<p>Loved it</p>".to_string()))
+    );
+}
+
+#[test]
+fn test_datetime_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("read_on", CustomColumnKind::Datetime))
+        .unwrap();
+
+    let dt = Utc.with_ymd_and_hms(2024, 1, 15, 10, 30, 0).unwrap();
+    lib.set_custom_value(book, col.id, Some(CustomValue::Datetime(dt)))
+        .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Datetime(dt))
+    );
+
+    // Stored in Calibre's on-disk format
+    let conn = raw_conn(&lib);
+    let raw: String = conn
+        .query_row(
+            &format!("SELECT value FROM custom_column_{} WHERE book = ?1", col.id),
+            [book.as_i32()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(raw, "2024-01-15 10:30:00+00:00");
+}
+
+#[test]
+fn test_enumeration_round_trip() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(CustomColumnSpec {
+            enum_values: vec![
+                "want-to-read".to_string(),
+                "reading".to_string(),
+                "read".to_string(),
+            ],
+            ..spec("status", CustomColumnKind::Enumeration)
+        })
+        .unwrap();
+    assert_eq!(
+        col.enum_values,
+        vec!["want-to-read", "reading", "read"]
+    );
+
+    lib.set_custom_value(
+        book,
+        col.id,
+        Some(CustomValue::Enumeration("reading".to_string())),
+    )
+    .unwrap();
+    assert_eq!(
+        lib.get_custom_value(book, col.id).unwrap(),
+        Some(CustomValue::Enumeration("reading".to_string()))
+    );
+
+    // Empty enumeration value clears
+    lib.set_custom_value(
+        book,
+        col.id,
+        Some(CustomValue::Enumeration(String::new())),
+    )
+    .unwrap();
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+}
+
+#[test]
+fn test_batch_get_custom_values() {
+    let (_temp, mut lib) = setup_with_library();
+    let book1 = add_book(&mut lib);
+    let book2 = add_book(&mut lib);
+    let book3 = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(spec("pages", CustomColumnKind::Int))
+        .unwrap();
+
+    lib.set_custom_value(book1, col.id, Some(CustomValue::Int(100)))
+        .unwrap();
+    lib.set_custom_value(book2, col.id, Some(CustomValue::Int(200)))
+        .unwrap();
+
+    let values = lib
+        .batch_get_custom_values(col.id, &[book1, book2, book3])
+        .unwrap();
+    assert_eq!(values.len(), 2);
+    assert_eq!(values.get(&book1), Some(&CustomValue::Int(100)));
+    assert_eq!(values.get(&book2), Some(&CustomValue::Int(200)));
+    assert_eq!(values.get(&book3), None);
+}
+
+#[test]
+fn test_get_custom_values_for_book_skips_unsupported() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+
+    let pages = lib
+        .create_custom_column(spec("pages", CustomColumnKind::Int))
+        .unwrap();
+    let mood = lib
+        .create_custom_column(spec("mood", CustomColumnKind::Text))
+        .unwrap();
+    // Unsupported kind: enumerable but not readable/writable
+    let saga = lib
+        .create_custom_column(spec("saga", CustomColumnKind::Series))
+        .unwrap();
+
+    lib.set_custom_value(book, pages.id, Some(CustomValue::Int(42)))
+        .unwrap();
+    lib.set_custom_value(book, mood.id, Some(CustomValue::Text("cozy".to_string())))
+        .unwrap();
+
+    let values = lib.get_custom_values_for_book(book).unwrap();
+    assert_eq!(values.get(&pages.id), Some(&CustomValue::Int(42)));
+    assert_eq!(
+        values.get(&mood.id),
+        Some(&CustomValue::Text("cozy".to_string()))
+    );
+    assert!(!values.contains_key(&saga.id));
+}
+
+// =============================================================================
+// 2. "Calibre wrote it, we read it"
+// =============================================================================
+
+/// Execute the DDL Calibre emits for a column, verbatim (except for the
+/// column number substitution).
+fn calibre_normalized_ddl(conn: &rusqlite::Connection, n: i64, dt: &str, s_index: &str) {
+    let collate = if dt == "TEXT" { "COLLATE NOCASE" } else { "" };
+    conn.execute_batch(&format!(
+        r#"CREATE TABLE custom_column_{n}(
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    value {dt} NOT NULL {collate},
+    link TEXT NOT NULL DEFAULT "",
+    UNIQUE(value));
+CREATE INDEX custom_column_{n}_idx ON custom_column_{n} (value {collate});
+CREATE TABLE books_custom_column_{n}_link(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    book INTEGER NOT NULL,
+    value INTEGER NOT NULL,
+    {s_index}
+    UNIQUE(book, value)
+    );
+CREATE INDEX books_custom_column_{n}_link_aidx ON books_custom_column_{n}_link (value);
+CREATE INDEX books_custom_column_{n}_link_bidx ON books_custom_column_{n}_link (book);
+CREATE TRIGGER fkc_update_books_custom_column_{n}_link_a
+        BEFORE UPDATE OF book ON books_custom_column_{n}_link
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+            END;
+        END;
+CREATE TRIGGER fkc_update_books_custom_column_{n}_link_b
+        BEFORE UPDATE OF author ON books_custom_column_{n}_link
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from custom_column_{n} WHERE id=NEW.value) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: value not in custom_column_{n}')
+            END;
+        END;
+CREATE TRIGGER fkc_insert_books_custom_column_{n}_link
+        BEFORE INSERT ON books_custom_column_{n}_link
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+                WHEN (SELECT id from custom_column_{n} WHERE id=NEW.value) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: value not in custom_column_{n}')
+            END;
+        END;
+CREATE TRIGGER fkc_delete_books_custom_column_{n}_link
+        AFTER DELETE ON custom_column_{n}
+        BEGIN
+            DELETE FROM books_custom_column_{n}_link WHERE value=OLD.id;
+        END;
+CREATE VIEW tag_browser_custom_column_{n} AS SELECT
+    id,
+    value,
+    (SELECT COUNT(id) FROM books_custom_column_{n}_link WHERE value=custom_column_{n}.id) count,
+    (SELECT AVG(r.rating)
+     FROM books_custom_column_{n}_link,
+          books_ratings_link as bl,
+          ratings as r
+     WHERE books_custom_column_{n}_link.value=custom_column_{n}.id and bl.book=books_custom_column_{n}_link.book and
+           r.id = bl.rating and r.rating <> 0) avg_rating,
+    value AS sort
+FROM custom_column_{n};
+CREATE VIEW tag_browser_filtered_custom_column_{n} AS SELECT
+    id,
+    value,
+    (SELECT COUNT(books_custom_column_{n}_link.id) FROM books_custom_column_{n}_link WHERE value=custom_column_{n}.id AND
+    books_list_filter(book)) count,
+    (SELECT AVG(r.rating)
+     FROM books_custom_column_{n}_link,
+          books_ratings_link as bl,
+          ratings as r
+     WHERE books_custom_column_{n}_link.value=custom_column_{n}.id AND bl.book=books_custom_column_{n}_link.book AND
+           r.id = bl.rating AND r.rating <> 0 AND
+           books_list_filter(bl.book)) avg_rating,
+    value AS sort
+FROM custom_column_{n};
+"#
+    ))
+    .unwrap();
+}
+
+fn calibre_non_normalized_ddl(conn: &rusqlite::Connection, n: i64, dt: &str) {
+    let collate = if dt == "TEXT" { "COLLATE NOCASE" } else { "" };
+    conn.execute_batch(&format!(
+        r#"CREATE TABLE custom_column_{n}(
+    id    INTEGER PRIMARY KEY AUTOINCREMENT,
+    book  INTEGER,
+    value {dt} NOT NULL {collate},
+    UNIQUE(book));
+CREATE INDEX custom_column_{n}_idx ON custom_column_{n} (book);
+CREATE TRIGGER fkc_insert_custom_column_{n}
+        BEFORE INSERT ON custom_column_{n}
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+            END;
+        END;
+CREATE TRIGGER fkc_update_custom_column_{n}
+        BEFORE UPDATE OF book ON custom_column_{n}
+        BEGIN
+            SELECT CASE
+                WHEN (SELECT id from books WHERE id=NEW.book) IS NULL
+                THEN RAISE(ABORT, 'Foreign key violation: book not in books')
+            END;
+        END;
+"#
+    ))
+    .unwrap();
+}
+
+fn insert_custom_columns_row(
+    conn: &rusqlite::Connection,
+    label: &str,
+    name: &str,
+    datatype: &str,
+    is_multiple: bool,
+    normalized: bool,
+    display: &str,
+) -> i64 {
+    conn.execute(
+        "INSERT INTO custom_columns (label, name, datatype, mark_for_delete, editable, display, is_multiple, normalized)
+         VALUES (?1, ?2, ?3, 0, 1, ?4, ?5, ?6)",
+        rusqlite::params![label, name, datatype, display, is_multiple, normalized],
+    )
+    .unwrap();
+    conn.last_insert_rowid()
+}
+
+#[test]
+fn test_calibre_created_columns_are_read_correctly() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib); // also creates the `read` column (id 1)
+
+    let conn = raw_conn(&lib);
+
+    // Enumeration column, as Calibre creates it
+    let status_id = insert_custom_columns_row(
+        &conn,
+        "status",
+        "Status",
+        "enumeration",
+        false,
+        true,
+        r#"{"enum_values": ["want-to-read", "reading", "read"], "enum_colors": []}"#,
+    );
+    calibre_normalized_ddl(&conn, status_id, "TEXT", "");
+    conn.execute(
+        &format!("INSERT INTO custom_column_{status_id} (value, link) VALUES ('reading', '')"),
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        &format!(
+            "INSERT INTO books_custom_column_{status_id}_link (book, value)
+             VALUES (?1, (SELECT id FROM custom_column_{status_id} WHERE value = 'reading'))"
+        ),
+        [book.as_i32()],
+    )
+    .unwrap();
+
+    // Multiple-text column with two link rows
+    let genres_id = insert_custom_columns_row(
+        &conn,
+        "genres",
+        "Genres",
+        "text",
+        true,
+        true,
+        r#"{"is_names": false, "description": ""}"#,
+    );
+    calibre_normalized_ddl(&conn, genres_id, "TEXT", "");
+    for value in ["fantasy", "epic"] {
+        conn.execute(
+            &format!("INSERT INTO custom_column_{genres_id} (value, link) VALUES (?1, '')"),
+            [value],
+        )
+        .unwrap();
+        conn.execute(
+            &format!(
+                "INSERT INTO books_custom_column_{genres_id}_link (book, value)
+                 VALUES (?1, (SELECT id FROM custom_column_{genres_id} WHERE value = ?2))"
+            ),
+            rusqlite::params![book.as_i32(), value],
+        )
+        .unwrap();
+    }
+
+    // Datetime column, with a fractional-seconds value
+    let released_id = insert_custom_columns_row(
+        &conn,
+        "released",
+        "Released",
+        "datetime",
+        false,
+        false,
+        "{}",
+    );
+    calibre_non_normalized_ddl(&conn, released_id, "timestamp");
+    conn.execute(
+        &format!(
+            "INSERT INTO custom_column_{released_id} (book, value)
+             VALUES (?1, '2024-03-02T08:15:30.123456+00:00')"
+        ),
+        [book.as_i32()],
+    )
+    .unwrap();
+    drop(conn);
+
+    // Enumerate
+    let columns = lib.custom_columns().unwrap();
+    let status = columns.iter().find(|c| c.label == "status").unwrap();
+    assert_eq!(status.kind, CustomColumnKind::Enumeration);
+    assert!(status.normalized);
+    assert_eq!(
+        status.enum_values,
+        vec!["want-to-read", "reading", "read"]
+    );
+
+    let genres = columns.iter().find(|c| c.label == "genres").unwrap();
+    assert_eq!(genres.kind, CustomColumnKind::Text);
+    assert!(genres.is_multiple);
+
+    let released = columns.iter().find(|c| c.label == "released").unwrap();
+    assert_eq!(released.kind, CustomColumnKind::Datetime);
+    assert!(!released.normalized);
+
+    // Read the Calibre-seeded values
+    assert_eq!(
+        lib.get_custom_value(book, status.id).unwrap(),
+        Some(CustomValue::Enumeration("reading".to_string()))
+    );
+
+    let Some(CustomValue::TextMultiple(mut genre_values)) =
+        lib.get_custom_value(book, genres.id).unwrap()
+    else {
+        panic!("expected TextMultiple");
+    };
+    genre_values.sort();
+    assert_eq!(genre_values, vec!["epic".to_string(), "fantasy".to_string()]);
+
+    let expected = Utc.with_ymd_and_hms(2024, 3, 2, 8, 15, 30).unwrap()
+        + chrono::Duration::microseconds(123456);
+    assert_eq!(
+        lib.get_custom_value(book, released.id).unwrap(),
+        Some(CustomValue::Datetime(expected))
+    );
+}
+
+// =============================================================================
+// 3. "We wrote it, Calibre reads it" (raw table contents)
+// =============================================================================
+
+#[test]
+fn test_written_values_match_calibre_raw_format() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+
+    // Normalized text: value row + link row
+    let mood = lib
+        .create_custom_column(spec("mood", CustomColumnKind::Text))
+        .unwrap();
+    lib.set_custom_value(book, mood.id, Some(CustomValue::Text("cozy".to_string())))
+        .unwrap();
+
+    {
+        let conn = raw_conn(&lib);
+        let n = mood.id;
+        let (value_id, value): (i64, String) = conn
+            .query_row(
+                &format!("SELECT id, value FROM custom_column_{n}"),
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(value, "cozy");
+
+        let (link_book, link_value): (i64, i64) = conn
+            .query_row(
+                &format!("SELECT book, value FROM books_custom_column_{n}_link"),
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(link_book, book.as_i32() as i64);
+        assert_eq!(link_value, value_id);
+    }
+
+    // Replacing prunes the orphaned value row
+    lib.set_custom_value(book, mood.id, Some(CustomValue::Text("grim".to_string())))
+        .unwrap();
+    {
+        let conn = raw_conn(&lib);
+        let n = mood.id;
+        let values: Vec<String> = conn
+            .prepare(&format!("SELECT value FROM custom_column_{n}"))
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(values, vec!["grim".to_string()]);
+    }
+
+    // Non-normalized bool: (book, value) row
+    let finished = lib
+        .create_custom_column(spec("finished", CustomColumnKind::Bool))
+        .unwrap();
+    lib.set_custom_value(book, finished.id, Some(CustomValue::Bool(true)))
+        .unwrap();
+    {
+        let conn = raw_conn(&lib);
+        let n = finished.id;
+        let (row_book, row_value): (i64, i64) = conn
+            .query_row(
+                &format!("SELECT book, value FROM custom_column_{n}"),
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(row_book, book.as_i32() as i64);
+        assert_eq!(row_value, 1);
+
+        // Table shape matches Calibre: book column with no NOT NULL, BOOL value
+        let create_sql: String = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?1",
+                [format!("custom_column_{n}")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(create_sql.contains("AUTOINCREMENT"), "{create_sql}");
+        assert!(create_sql.contains("UNIQUE(book)"), "{create_sql}");
+    }
+
+    // Case-insensitive value reuse: a second book setting "COZY"... must not
+    // violate the COLLATE NOCASE UNIQUE constraint.
+    let book2 = add_book(&mut lib);
+    lib.set_custom_value(book, mood.id, Some(CustomValue::Text("cozy".to_string())))
+        .unwrap();
+    lib.set_custom_value(book2, mood.id, Some(CustomValue::Text("COZY".to_string())))
+        .unwrap();
+    {
+        let conn = raw_conn(&lib);
+        let n = mood.id;
+        let value_count: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM custom_column_{n}"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(value_count, 1, "case-insensitive match must reuse the row");
+        let link_count: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM books_custom_column_{n}_link"),
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(link_count, 2);
+    }
+}
+
+#[test]
+fn test_legacy_citadel_read_table_still_works() {
+    let (_temp, mut lib) = setup_with_library();
+
+    // Simulate the table shape older Citadel versions created for `read`,
+    // BEFORE any library call auto-creates the new-style column.
+    let conn = raw_conn(&lib);
+    let n = insert_custom_columns_row(&conn, "read", "Read", "bool", false, false, "{}");
+    conn.execute(
+        &format!(
+            "CREATE TABLE custom_column_{n} \
+             (id INTEGER PRIMARY KEY, book INTEGER NOT NULL UNIQUE, value INTEGER NOT NULL)"
+        ),
+        [],
+    )
+    .unwrap();
+    drop(conn);
+
+    let book = add_book(&mut lib);
+    assert!(!lib.get_book_read_state(book).unwrap());
+    lib.set_book_read_state(book, true).unwrap();
+    assert!(lib.get_book_read_state(book).unwrap());
+    assert_eq!(
+        lib.batch_get_read_states(&[book]).unwrap().get(&book),
+        Some(&true)
+    );
+
+    // No duplicate `read` column was created
+    let read_columns = lib
+        .custom_columns()
+        .unwrap()
+        .into_iter()
+        .filter(|c| c.label == "read")
+        .count();
+    assert_eq!(read_columns, 1);
+}
+
+// =============================================================================
+// 4 & 5. Validation errors
+// =============================================================================
+
+#[test]
+fn test_enumeration_rejects_unknown_value() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+    let col = lib
+        .create_custom_column(CustomColumnSpec {
+            enum_values: vec!["yes".to_string(), "no".to_string()],
+            ..spec("verdict", CustomColumnKind::Enumeration)
+        })
+        .unwrap();
+
+    let result = lib.set_custom_value(
+        book,
+        col.id,
+        Some(CustomValue::Enumeration("maybe".to_string())),
+    );
+    assert!(matches!(result, Err(CalibreError::InvalidCustomValue(_))));
+    assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
+}
+
+#[test]
+fn test_type_mismatch_errors() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+
+    let flag = lib
+        .create_custom_column(spec("flag", CustomColumnKind::Bool))
+        .unwrap();
+    let result = lib.set_custom_value(book, flag.id, Some(CustomValue::Text("yes".to_string())));
+    assert!(matches!(result, Err(CalibreError::InvalidCustomValue(_))));
+
+    // Single text column rejects TextMultiple, and vice versa
+    let mood = lib
+        .create_custom_column(spec("mood", CustomColumnKind::Text))
+        .unwrap();
+    let result = lib.set_custom_value(
+        book,
+        mood.id,
+        Some(CustomValue::TextMultiple(vec!["a".to_string()])),
+    );
+    assert!(matches!(result, Err(CalibreError::InvalidCustomValue(_))));
+
+    let genres = lib
+        .create_custom_column(CustomColumnSpec {
+            is_multiple: true,
+            ..spec("genres", CustomColumnKind::Text)
+        })
+        .unwrap();
+    let result = lib.set_custom_value(book, genres.id, Some(CustomValue::Text("a".to_string())));
+    assert!(matches!(result, Err(CalibreError::InvalidCustomValue(_))));
+}
+
+#[test]
+fn test_unsupported_kinds_enumerate_but_reject_get_set() {
+    let (_temp, mut lib) = setup_with_library();
+    let book = add_book(&mut lib);
+
+    let saga = lib
+        .create_custom_column(spec("saga", CustomColumnKind::Series))
+        .unwrap();
+    assert_eq!(saga.kind, CustomColumnKind::Series);
+    assert!(saga.normalized);
+
+    let stars = lib
+        .create_custom_column(spec("stars", CustomColumnKind::Rating))
+        .unwrap();
+    assert_eq!(stars.kind, CustomColumnKind::Rating);
+
+    let listed: Vec<String> = lib
+        .custom_columns()
+        .unwrap()
+        .into_iter()
+        .map(|c| c.label)
+        .collect();
+    assert!(listed.contains(&"saga".to_string()));
+    assert!(listed.contains(&"stars".to_string()));
+
+    assert!(matches!(
+        lib.get_custom_value(book, saga.id),
+        Err(CalibreError::UnsupportedCustomColumn(_))
+    ));
+    assert!(matches!(
+        lib.set_custom_value(book, saga.id, Some(CustomValue::Text("x".to_string()))),
+        Err(CalibreError::UnsupportedCustomColumn(_))
+    ));
+    assert!(matches!(
+        lib.batch_get_custom_values(stars.id, &[book]),
+        Err(CalibreError::UnsupportedCustomColumn(_))
+    ));
+}
+
+#[test]
+fn test_create_rejects_invalid_specs() {
+    let (_temp, mut lib) = setup_with_library();
+
+    // Bad labels
+    for bad_label in ["1pages", "_pages", "pa-ges", "pa ges", ""] {
+        let result = lib.create_custom_column(spec(bad_label, CustomColumnKind::Int));
+        assert!(
+            matches!(result, Err(CalibreError::InvalidCustomColumn(_))),
+            "label {bad_label:?} should be rejected"
+        );
+    }
+
+    // Uppercase labels are lowercased, like Calibre does
+    let col = lib
+        .create_custom_column(spec("Pages", CustomColumnKind::Int))
+        .unwrap();
+    assert_eq!(col.label, "pages");
+
+    // is_multiple only for text
+    let result = lib.create_custom_column(CustomColumnSpec {
+        is_multiple: true,
+        ..spec("counts", CustomColumnKind::Int)
+    });
+    assert!(matches!(result, Err(CalibreError::InvalidCustomColumn(_))));
+}
+
+// =============================================================================
+// 6. Read-state regression (on top of the generic API)
+// =============================================================================
+
+#[test]
+fn test_read_state_uses_bool_custom_column() {
+    let (_temp, mut lib) = setup_with_library();
+    let book1 = add_book(&mut lib);
+    let book2 = add_book(&mut lib);
+
+    // Missing value maps to false
+    assert!(!lib.get_book_read_state(book1).unwrap());
+
+    lib.set_book_read_state(book1, true).unwrap();
+    assert!(lib.get_book_read_state(book1).unwrap());
+
+    let states = lib.batch_get_read_states(&[book1, book2]).unwrap();
+    assert_eq!(states.get(&book1), Some(&true));
+    // book2 never had its state set: no row at all
+    assert_eq!(states.get(&book2), None);
+
+    lib.set_book_read_state(book1, false).unwrap();
+    assert!(!lib.get_book_read_state(book1).unwrap());
+    // Explicit false is stored as a row (Calibre tri-state "no")
+    let states = lib.batch_get_read_states(&[book1]).unwrap();
+    assert_eq!(states.get(&book1), Some(&false));
+
+    // The column itself is a proper bool custom column
+    let columns = lib.custom_columns().unwrap();
+    let read = columns.iter().find(|c| c.label == "read").unwrap();
+    assert_eq!(read.kind, CustomColumnKind::Bool);
+    assert!(!read.is_multiple);
+    assert!(!read.normalized);
+
+    // And it is reachable through the generic value API
+    lib.set_book_read_state(book1, true).unwrap();
+    assert_eq!(
+        lib.get_custom_value(book1, read.id).unwrap(),
+        Some(CustomValue::Bool(true))
+    );
+}

--- a/crates/libcalibre/tests/custom_columns_test.rs
+++ b/crates/libcalibre/tests/custom_columns_test.rs
@@ -3,9 +3,7 @@ mod common;
 
 use chrono::{TimeZone, Utc};
 use common::{setup_with_library, standard_test_book};
-use libcalibre::{
-    BookId, CalibreError, CustomColumnKind, CustomColumnSpec, CustomValue, Library,
-};
+use libcalibre::{BookId, CalibreError, CustomColumnKind, CustomColumnSpec, CustomValue, Library};
 
 fn spec(label: &str, kind: CustomColumnKind) -> CustomColumnSpec {
     CustomColumnSpec {
@@ -223,10 +221,7 @@ fn test_enumeration_round_trip() {
             ..spec("status", CustomColumnKind::Enumeration)
         })
         .unwrap();
-    assert_eq!(
-        col.enum_values,
-        vec!["want-to-read", "reading", "read"]
-    );
+    assert_eq!(col.enum_values, vec!["want-to-read", "reading", "read"]);
 
     lib.set_custom_value(
         book,
@@ -240,12 +235,8 @@ fn test_enumeration_round_trip() {
     );
 
     // Empty enumeration value clears
-    lib.set_custom_value(
-        book,
-        col.id,
-        Some(CustomValue::Enumeration(String::new())),
-    )
-    .unwrap();
+    lib.set_custom_value(book, col.id, Some(CustomValue::Enumeration(String::new())))
+        .unwrap();
     assert_eq!(lib.get_custom_value(book, col.id).unwrap(), None);
 }
 
@@ -419,7 +410,8 @@ fn test_empty_text_values_clear() {
         ])),
     )
     .unwrap();
-    let Some(CustomValue::TextMultiple(mut values)) = lib.get_custom_value(book, genres.id).unwrap()
+    let Some(CustomValue::TextMultiple(mut values)) =
+        lib.get_custom_value(book, genres.id).unwrap()
     else {
         panic!("expected TextMultiple");
     };
@@ -664,13 +656,7 @@ fn test_calibre_created_columns_are_read_correctly() {
 
     // Datetime column, with a fractional-seconds value
     let released_id = insert_custom_columns_row(
-        &conn,
-        "released",
-        "Released",
-        "datetime",
-        false,
-        false,
-        "{}",
+        &conn, "released", "Released", "datetime", false, false, "{}",
     );
     calibre_non_normalized_ddl(&conn, released_id, "timestamp");
     conn.execute(
@@ -688,10 +674,7 @@ fn test_calibre_created_columns_are_read_correctly() {
     let status = columns.iter().find(|c| c.label == "status").unwrap();
     assert_eq!(status.kind, CustomColumnKind::Enumeration);
     assert!(status.normalized);
-    assert_eq!(
-        status.enum_values,
-        vec!["want-to-read", "reading", "read"]
-    );
+    assert_eq!(status.enum_values, vec!["want-to-read", "reading", "read"]);
 
     let genres = columns.iter().find(|c| c.label == "genres").unwrap();
     assert_eq!(genres.kind, CustomColumnKind::Text);
@@ -713,7 +696,10 @@ fn test_calibre_created_columns_are_read_correctly() {
         panic!("expected TextMultiple");
     };
     genre_values.sort();
-    assert_eq!(genre_values, vec!["epic".to_string(), "fantasy".to_string()]);
+    assert_eq!(
+        genre_values,
+        vec!["epic".to_string(), "fantasy".to_string()]
+    );
 
     let expected = Utc.with_ymd_and_hms(2024, 3, 2, 8, 15, 30).unwrap()
         + chrono::Duration::microseconds(123456);

--- a/crates/libcalibre/tests/snapshots/add_book_test__add_single_book_full_database.snap
+++ b/crates/libcalibre/tests/snapshots/add_book_test__add_single_book_full_database.snap
@@ -1,6 +1,5 @@
 ---
-source: libcalibre/tests/add_book_test.rs
-assertion_line: 22
+source: crates/libcalibre/tests/add_book_test.rs
 expression: snapshot
 ---
 schema:
@@ -366,10 +365,10 @@ schema:
         primary_key: true
       - name: book
         type_name: INTEGER
-        nullable: false
+        nullable: true
         primary_key: false
       - name: value
-        type_name: INTEGER
+        type_name: BOOL
         nullable: false
         primary_key: false
   - name: custom_columns

--- a/src-tauri/src/libs/calibre/command.rs
+++ b/src-tauri/src/libs/calibre/command.rs
@@ -5,6 +5,7 @@ use crate::book::LibraryAuthor;
 use crate::calibre::author::NewAuthor;
 use crate::state::CitadelState;
 
+use super::custom_columns::CustomValueDto;
 use super::AuthorUpdate;
 use super::BookUpdate;
 
@@ -23,6 +24,22 @@ pub fn clb_cmd_update_book(
         )
         .map(|entry| entry.id.as_i32())
         .map_err(|e| e.to_string())
+    })?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clb_cmd_set_custom_value(
+    state: tauri::State<CitadelState>,
+    book_id: String,
+    column_id: i32,
+    value: Option<CustomValueDto>,
+) -> Result<(), String> {
+    state.with_library(|lib| {
+        let book_id_int = book_id.parse::<i32>().map_err(|e| e.to_string())?;
+        let value = value.map(libcalibre::CustomValue::try_from).transpose()?;
+        lib.set_custom_value(libcalibre::BookId::from(book_id_int), column_id, value)
+            .map_err(|e| e.to_string())
     })?
 }
 

--- a/src-tauri/src/libs/calibre/custom_columns.rs
+++ b/src-tauri/src/libs/calibre/custom_columns.rs
@@ -95,3 +95,53 @@ pub struct BookCustomValue {
     pub column_id: i32,
     pub value: CustomValueDto,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn int_out_of_i32_range_yields_err() {
+        let too_big = libcalibre::CustomValue::Int(i64::from(i32::MAX) + 1);
+        assert!(CustomValueDto::try_from(too_big).is_err());
+
+        let too_small = libcalibre::CustomValue::Int(i64::from(i32::MIN) - 1);
+        assert!(CustomValueDto::try_from(too_small).is_err());
+
+        let in_range = libcalibre::CustomValue::Int(i64::from(i32::MAX));
+        let dto = CustomValueDto::try_from(in_range).unwrap();
+        assert!(matches!(dto, CustomValueDto::Int(i) if i == i32::MAX));
+    }
+
+    #[test]
+    fn datetime_round_trips_both_directions() {
+        // libcalibre -> DTO
+        let dt = Utc.with_ymd_and_hms(2024, 1, 15, 10, 30, 0).unwrap();
+        let dto = CustomValueDto::try_from(libcalibre::CustomValue::Datetime(dt)).unwrap();
+        let CustomValueDto::Datetime(raw) = &dto else {
+            panic!("expected Datetime DTO");
+        };
+        assert_eq!(raw, "2024-01-15T10:30:00+00:00");
+
+        // DTO -> libcalibre, back to the same instant
+        let value = libcalibre::CustomValue::try_from(dto).unwrap();
+        assert_eq!(value, libcalibre::CustomValue::Datetime(dt));
+
+        // RFC3339 string with a non-UTC offset normalizes to the same instant
+        let offset_dto = CustomValueDto::Datetime("2024-01-15T11:30:00+01:00".to_string());
+        let value = libcalibre::CustomValue::try_from(offset_dto).unwrap();
+        assert_eq!(value, libcalibre::CustomValue::Datetime(dt));
+    }
+
+    #[test]
+    fn invalid_datetime_string_yields_err() {
+        for raw in ["not a date", "", "2024-01-15", "2024-01-15 10:30:00"] {
+            let dto = CustomValueDto::Datetime(raw.to_string());
+            assert!(
+                libcalibre::CustomValue::try_from(dto).is_err(),
+                "'{raw}' should be rejected"
+            );
+        }
+    }
+}

--- a/src-tauri/src/libs/calibre/custom_columns.rs
+++ b/src-tauri/src/libs/calibre/custom_columns.rs
@@ -1,0 +1,97 @@
+//! DTOs bridging libcalibre's custom-column types across the Tauri boundary.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A custom column definition, as exposed to the frontend.
+#[derive(Serialize, Deserialize, specta::Type, Debug)]
+pub struct CustomColumnDef {
+    pub column_id: i32,
+    /// Lookup name, e.g. `read` (Calibre exposes it as `#read`).
+    pub label: String,
+    /// Human-readable heading, e.g. `Read`.
+    pub name: String,
+    /// Raw Calibre datatype string, e.g. `bool`, `text`, `enumeration`.
+    pub datatype: String,
+    pub is_multiple: bool,
+    pub editable: bool,
+    /// Whether reading and writing values of this column is supported.
+    pub supported: bool,
+    /// Allowed values for enumeration columns. Empty for other datatypes.
+    pub enum_values: Vec<String>,
+}
+
+impl From<&libcalibre::CustomColumn> for CustomColumnDef {
+    fn from(column: &libcalibre::CustomColumn) -> Self {
+        Self {
+            column_id: column.id,
+            label: column.label.clone(),
+            name: column.name.clone(),
+            datatype: column.kind.datatype().to_string(),
+            is_multiple: column.is_multiple,
+            editable: column.editable,
+            supported: column.kind.supports_value_io(),
+            enum_values: column.enum_values.clone(),
+        }
+    }
+}
+
+/// A custom-column value crossing the Tauri boundary.
+///
+/// Mirrors `libcalibre::CustomValue`, except datetimes travel as RFC3339
+/// strings and integers as `i32` (specta cannot export `i64` without bigint
+/// support).
+#[derive(Serialize, Deserialize, specta::Type, Debug, Clone)]
+pub enum CustomValueDto {
+    Bool(bool),
+    Int(i32),
+    Float(f64),
+    Text(String),
+    TextMultiple(Vec<String>),
+    /// RFC3339 datetime string, e.g. `2024-01-15T10:30:00+00:00`.
+    Datetime(String),
+    Enumeration(String),
+}
+
+impl TryFrom<libcalibre::CustomValue> for CustomValueDto {
+    type Error = String;
+
+    fn try_from(value: libcalibre::CustomValue) -> Result<Self, Self::Error> {
+        match value {
+            libcalibre::CustomValue::Bool(b) => Ok(Self::Bool(b)),
+            libcalibre::CustomValue::Int(i) => i32::try_from(i)
+                .map(Self::Int)
+                .map_err(|_| format!("integer value {} is out of range", i)),
+            libcalibre::CustomValue::Float(f) => Ok(Self::Float(f)),
+            libcalibre::CustomValue::Text(s) => Ok(Self::Text(s)),
+            libcalibre::CustomValue::TextMultiple(values) => Ok(Self::TextMultiple(values)),
+            libcalibre::CustomValue::Datetime(dt) => Ok(Self::Datetime(dt.to_rfc3339())),
+            libcalibre::CustomValue::Enumeration(s) => Ok(Self::Enumeration(s)),
+        }
+    }
+}
+
+impl TryFrom<CustomValueDto> for libcalibre::CustomValue {
+    type Error = String;
+
+    fn try_from(value: CustomValueDto) -> Result<Self, Self::Error> {
+        match value {
+            CustomValueDto::Bool(b) => Ok(Self::Bool(b)),
+            CustomValueDto::Int(i) => Ok(Self::Int(i64::from(i))),
+            CustomValueDto::Float(f) => Ok(Self::Float(f)),
+            CustomValueDto::Text(s) => Ok(Self::Text(s)),
+            CustomValueDto::TextMultiple(values) => Ok(Self::TextMultiple(values)),
+            CustomValueDto::Datetime(raw) => DateTime::parse_from_rfc3339(&raw)
+                .map(|dt| Self::Datetime(dt.with_timezone(&Utc)))
+                .map_err(|e| format!("invalid RFC3339 datetime '{}': {}", raw, e)),
+            CustomValueDto::Enumeration(s) => Ok(Self::Enumeration(s)),
+        }
+    }
+}
+
+/// One book's value for one custom column.
+#[derive(Serialize, Deserialize, specta::Type, Debug)]
+pub struct BookCustomValue {
+    pub column_id: i32,
+    pub value: CustomValueDto,
+}

--- a/src-tauri/src/libs/calibre/mod.rs
+++ b/src-tauri/src/libs/calibre/mod.rs
@@ -10,6 +10,7 @@ mod author;
 mod book;
 
 pub mod command;
+pub mod custom_columns;
 pub mod query;
 
 #[derive(Serialize, Deserialize, specta::Type, Debug)]

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -7,6 +7,7 @@ use crate::calibre::book;
 use crate::libs::file_formats;
 use crate::{book::LibraryBook, state::CitadelState};
 
+use super::custom_columns::{BookCustomValue, CustomColumnDef, CustomValueDto};
 use super::ImportableFile;
 
 #[tauri::command]
@@ -59,6 +60,41 @@ pub fn clb_query_list_all_filetypes() -> Vec<(String, String)> {
                 .map(|mimetype| (mimetype.as_str().to_string(), extension.to_string()))
         })
         .collect()
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_list_custom_columns(
+    state: tauri::State<CitadelState>,
+) -> Result<Vec<CustomColumnDef>, String> {
+    state.with_library(|lib| {
+        lib.custom_columns()
+            .map(|columns| columns.iter().map(CustomColumnDef::from).collect())
+            .map_err(|e| e.to_string())
+    })?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_get_custom_values_for_book(
+    state: tauri::State<CitadelState>,
+    book_id: String,
+) -> Result<Vec<BookCustomValue>, String> {
+    state.with_library(|lib| {
+        let book_id_int = book_id.parse::<i32>().map_err(|e| e.to_string())?;
+        let values = lib
+            .get_custom_values_for_book(libcalibre::BookId::from(book_id_int))
+            .map_err(|e| e.to_string())?;
+
+        let mut book_values = values
+            .into_iter()
+            .map(|(column_id, value)| {
+                CustomValueDto::try_from(value).map(|value| BookCustomValue { column_id, value })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        book_values.sort_by_key(|book_value| book_value.column_id);
+        Ok(book_values)
+    })?
 }
 
 #[tauri::command]

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -86,12 +86,17 @@ pub fn clb_query_get_custom_values_for_book(
             .get_custom_values_for_book(libcalibre::BookId::from(book_id_int))
             .map_err(|e| e.to_string())?;
 
+        // Skip values that cannot cross the Tauri boundary (e.g. an i64 out
+        // of i32 range) instead of failing the whole command and hiding
+        // every other column from the UI.
         let mut book_values = values
             .into_iter()
-            .map(|(column_id, value)| {
-                CustomValueDto::try_from(value).map(|value| BookCustomValue { column_id, value })
+            .filter_map(|(column_id, value)| {
+                CustomValueDto::try_from(value)
+                    .map(|value| BookCustomValue { column_id, value })
+                    .ok()
             })
-            .collect::<Result<Vec<_>, String>>()?;
+            .collect::<Vec<_>>();
         book_values.sort_by_key(|book_value| book_value.column_id);
         Ok(book_values)
     })?

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -35,6 +35,10 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::command::clb_cmd_upsert_book_identifier,
         calibre::command::clb_cmd_delete_book_identifier,
         calibre::command::clb_cmd_set_book_cover_from_url,
+        // Custom column commands
+        calibre::query::clb_query_list_custom_columns,
+        calibre::query::clb_query_get_custom_values_for_book,
+        calibre::command::clb_cmd_set_custom_value,
         // Author query and manipulation commands
         calibre::query::clb_query_list_all_authors,
         calibre::command::clb_cmd_create_authors,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -81,6 +81,30 @@ async clbCmdSetBookCoverFromUrl(bookId: string, imageUrl: string) : Promise<Resu
     else return { status: "error", error: e  as any };
 }
 },
+async clbQueryListCustomColumns() : Promise<Result<CustomColumnDef[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_list_custom_columns") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async clbQueryGetCustomValuesForBook(bookId: string) : Promise<Result<BookCustomValue[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_get_custom_values_for_book", { bookId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async clbCmdSetCustomValue(bookId: string, columnId: number, value: CustomValueDto | null) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_cmd_set_custom_value", { bookId, columnId, value }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbQueryListAllAuthors() : Promise<Result<LibraryAuthor[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clb_query_list_all_authors") };
@@ -177,6 +201,10 @@ async clbCmdOpenSettings() : Promise<void> {
 /** user-defined types **/
 
 export type AuthorUpdate = { full_name: string | null; sortable_name: string | null; external_url: string | null }
+/**
+ * One book's value for one custom column.
+ */
+export type BookCustomValue = { column_id: number; value: CustomValueDto }
 export type BookFile = { Local: LocalFile } | { Remote: RemoteFile }
 export type BookUpdate = { author_id_list: string[] | null; tag_list: string[] | null; title: string | null; timestamp: string | null; publication_date: string | null; is_read: boolean | null; description: string | null; 
 /**
@@ -185,6 +213,42 @@ export type BookUpdate = { author_id_list: string[] | null; tag_list: string[] |
  */
 series: string | null; series_index: number | null }
 export type CalibreClientConfig = { library_path: string }
+/**
+ * A custom column definition, as exposed to the frontend.
+ */
+export type CustomColumnDef = { column_id: number;
+/**
+ * Lookup name, e.g. `read` (Calibre exposes it as `#read`).
+ */
+label: string;
+/**
+ * Human-readable heading, e.g. `Read`.
+ */
+name: string;
+/**
+ * Raw Calibre datatype string, e.g. `bool`, `text`, `enumeration`.
+ */
+datatype: string; is_multiple: boolean; editable: boolean;
+/**
+ * Whether reading and writing values of this column is supported.
+ */
+supported: boolean;
+/**
+ * Allowed values for enumeration columns. Empty for other datatypes.
+ */
+enum_values: string[] }
+/**
+ * A custom-column value crossing the Tauri boundary.
+ *
+ * Mirrors `libcalibre::CustomValue`, except datetimes travel as RFC3339
+ * strings and integers as `i32` (specta cannot export `i64` without bigint
+ * support).
+ */
+export type CustomValueDto = { Bool: boolean } | { Int: number } | { Float: number } | { Text: string } | { TextMultiple: string[] } |
+/**
+ * RFC3339 datetime string, e.g. `2024-01-15T10:30:00+00:00`.
+ */
+{ Datetime: string } | { Enumeration: string }
 export type HardcoverApiStatus = { is_valid: boolean; message: string }
 export type HardcoverBookMetadata = { title: string; description: string | null; image_url: string | null; isbn: string | null; release_year: number | null; hardcover_id: number | null; slug: string | null }
 export type HardcoverSearchResult = { title: string; description: string | null; image_url: string | null; isbn: string | null; release_year: number | null; hardcover_id: number; slug: string | null; authors: string[] }

--- a/src/components/pages/EditBook.tsx
+++ b/src/components/pages/EditBook.tsx
@@ -355,40 +355,60 @@ const EditBookForm = ({
 		null,
 	);
 
-	const loadCustomColumns = useCallback(async () => {
-		const columnsResult = await commands.clbQueryListCustomColumns();
-		if (columnsResult.status === "error") {
-			throw new Error(columnsResult.error);
-		}
+	const loadCustomColumns = useCallback(
+		async (isCancelled: () => boolean = () => false) => {
+			const columnsResult = await commands.clbQueryListCustomColumns();
+			if (isCancelled()) {
+				return;
+			}
+			if (columnsResult.status === "error") {
+				throw new Error(columnsResult.error);
+			}
 
-		const editable = editableCustomColumns(columnsResult.data);
-		if (editable.length === 0) {
-			setCustomColumns([]);
-			setCustomSnapshot({});
-			setCustomValues({});
-			return;
-		}
+			const editable = editableCustomColumns(columnsResult.data);
+			if (editable.length === 0) {
+				setCustomColumns([]);
+				setCustomSnapshot({});
+				setCustomValues({});
+				return;
+			}
 
-		const valuesResult = await commands.clbQueryGetCustomValuesForBook(
-			book.id,
-		);
-		if (valuesResult.status === "error") {
-			throw new Error(valuesResult.error);
-		}
+			const valuesResult = await commands.clbQueryGetCustomValuesForBook(
+				book.id,
+			);
+			if (isCancelled()) {
+				return;
+			}
+			if (valuesResult.status === "error") {
+				throw new Error(valuesResult.error);
+			}
 
-		const fieldValues = buildCustomFieldValues(editable, valuesResult.data);
-		setCustomColumns(editable);
-		setCustomSnapshot(fieldValues);
-		setCustomValues(fieldValues);
-	}, [book.id]);
+			const fieldValues = buildCustomFieldValues(editable, valuesResult.data);
+			setCustomColumns(editable);
+			setCustomSnapshot(fieldValues);
+			setCustomValues(fieldValues);
+		},
+		[book.id],
+	);
 
 	useEffect(() => {
-		loadCustomColumns().catch((error: unknown) => {
+		let cancelled = false;
+		loadCustomColumns(() => cancelled).catch((error: unknown) => {
+			if (cancelled) {
+				return;
+			}
 			console.error(error);
 			setCustomColumnError(
 				error instanceof Error ? error.message : String(error),
 			);
+			// Do not leave the previous book's inputs rendered under the error.
+			setCustomColumns([]);
+			setCustomSnapshot({});
+			setCustomValues({});
 		});
+		return () => {
+			cancelled = true;
+		};
 	}, [loadCustomColumns]);
 
 	const customChanges = useMemo(

--- a/src/components/pages/EditBook.tsx
+++ b/src/components/pages/EditBook.tsx
@@ -9,18 +9,33 @@ import {
 	useMemo,
 	useState,
 } from "react";
-import type { BookUpdate, LibraryAuthor, LibraryBook } from "@/bindings";
+import {
+	type BookUpdate,
+	type CustomColumnDef,
+	type LibraryAuthor,
+	type LibraryBook,
+	commands,
+} from "@/bindings";
 import { HardcoverLogo } from "@/components/icons/HardcoverLogo";
 import {
 	Button,
 	IconButton,
+	Select,
 	Spinner,
 	Switch,
 	TagsInput,
+	Textarea,
 	TextInput,
 	Tooltip,
 } from "@/components/ui";
 import { safeAsyncEventHandler } from "@/lib/async";
+import {
+	type CustomFieldValue,
+	buildCustomFieldValues,
+	diffCustomValues,
+	editableCustomColumns,
+	emptyFieldValue,
+} from "@/lib/custom-columns";
 import { useHardcoverBookActions } from "@/lib/hooks/use-hardcover-book-actions";
 import { formatSeriesIndex } from "@/lib/series";
 import { BookCover } from "../atoms/BookCover";
@@ -158,6 +173,111 @@ interface EditBookFormValues {
 	isRead: boolean;
 }
 
+/** Sentinel for "no value" in pop-up buttons; Radix items cannot be "". */
+const UNSET_OPTION = "__unset__";
+
+const CustomColumnInput = ({
+	id,
+	column,
+	value,
+	onChange,
+}: {
+	id: string;
+	column: CustomColumnDef;
+	value: CustomFieldValue;
+	onChange: (value: CustomFieldValue) => void;
+}) => {
+	switch (column.datatype) {
+		case "bool":
+			return (
+				<Select
+					id={id}
+					aria-label={column.name}
+					options={[
+						{ value: UNSET_OPTION, label: "Unset" },
+						{ value: "yes", label: "Yes" },
+						{ value: "no", label: "No" },
+					]}
+					value={value === "yes" || value === "no" ? value : UNSET_OPTION}
+					onChange={(next) => onChange(next === UNSET_OPTION ? null : next)}
+				/>
+			);
+		case "int":
+		case "float":
+			return (
+				<TextInput
+					id={id}
+					inputMode={column.datatype === "int" ? "numeric" : "decimal"}
+					value={
+						typeof value === "number"
+							? String(value)
+							: typeof value === "string"
+								? value
+								: ""
+					}
+					onChange={(event) => onChange(event.target.value)}
+				/>
+			);
+		case "text":
+			if (column.is_multiple) {
+				return (
+					<TagsInput
+						id={id}
+						aria-label={column.name}
+						placeholder="Search or add value"
+						value={Array.isArray(value) ? value : []}
+						onChange={onChange}
+					/>
+				);
+			}
+			return (
+				<TextInput
+					id={id}
+					value={typeof value === "string" ? value : ""}
+					onChange={(event) => onChange(event.target.value)}
+				/>
+			);
+		case "comments":
+			return (
+				<Textarea
+					id={id}
+					rows={3}
+					value={typeof value === "string" ? value : ""}
+					onChange={(event) => onChange(event.target.value)}
+				/>
+			);
+		case "datetime":
+			return (
+				<TextInput
+					id={id}
+					placeholder="YYYY-MM-DD"
+					value={typeof value === "string" ? value : ""}
+					onChange={(event) => onChange(event.target.value)}
+				/>
+			);
+		case "enumeration":
+			return (
+				<Select
+					id={id}
+					aria-label={column.name}
+					options={[
+						{ value: UNSET_OPTION, label: "Unset" },
+						...column.enum_values.map((option) => ({
+							value: option,
+							label: option,
+						})),
+					]}
+					value={
+						typeof value === "string" && value !== "" ? value : UNSET_OPTION
+					}
+					onChange={(next) => onChange(next === UNSET_OPTION ? null : next)}
+				/>
+			);
+		default:
+			return null;
+	}
+};
+
 const formValuesFromBook = (book: LibraryBook): EditBookFormValues => ({
 	title: book.title,
 	sortTitle: book.sortable_title ?? "",
@@ -224,6 +344,102 @@ const EditBookForm = ({
 		[allAuthorList],
 	);
 
+	const [customColumns, setCustomColumns] = useState<CustomColumnDef[]>([]);
+	const [customSnapshot, setCustomSnapshot] = useState<
+		Record<string, CustomFieldValue>
+	>({});
+	const [customValues, setCustomValues] = useState<
+		Record<string, CustomFieldValue>
+	>({});
+	const [customColumnError, setCustomColumnError] = useState<string | null>(
+		null,
+	);
+
+	const loadCustomColumns = useCallback(async () => {
+		const columnsResult = await commands.clbQueryListCustomColumns();
+		if (columnsResult.status === "error") {
+			throw new Error(columnsResult.error);
+		}
+
+		const editable = editableCustomColumns(columnsResult.data);
+		if (editable.length === 0) {
+			setCustomColumns([]);
+			setCustomSnapshot({});
+			setCustomValues({});
+			return;
+		}
+
+		const valuesResult = await commands.clbQueryGetCustomValuesForBook(
+			book.id,
+		);
+		if (valuesResult.status === "error") {
+			throw new Error(valuesResult.error);
+		}
+
+		const fieldValues = buildCustomFieldValues(editable, valuesResult.data);
+		setCustomColumns(editable);
+		setCustomSnapshot(fieldValues);
+		setCustomValues(fieldValues);
+	}, [book.id]);
+
+	useEffect(() => {
+		loadCustomColumns().catch((error: unknown) => {
+			console.error(error);
+			setCustomColumnError(
+				error instanceof Error ? error.message : String(error),
+			);
+		});
+	}, [loadCustomColumns]);
+
+	const customChanges = useMemo(
+		() => diffCustomValues(customColumns, customSnapshot, customValues),
+		[customColumns, customSnapshot, customValues],
+	);
+
+	const saveCustomChanges = useCallback(async () => {
+		if (customChanges.length === 0) {
+			return;
+		}
+
+		const attemptedValues = { ...customValues };
+		const failures: { columnId: number; message: string }[] = [];
+		for (const change of customChanges) {
+			const result = await commands.clbCmdSetCustomValue(
+				book.id,
+				change.columnId,
+				change.value,
+			);
+			if (result.status === "error") {
+				const columnName =
+					customColumns.find((column) => column.column_id === change.columnId)
+						?.name ?? `column ${change.columnId}`;
+				failures.push({
+					columnId: change.columnId,
+					message: `${columnName}: ${result.error}`,
+				});
+			}
+		}
+
+		await loadCustomColumns();
+
+		if (failures.length > 0) {
+			// Keep the rejected inputs around so they can be fixed and re-saved.
+			setCustomValues((refreshed) => {
+				const next = { ...refreshed };
+				for (const failure of failures) {
+					const key = String(failure.columnId);
+					next[key] = attemptedValues[key] ?? next[key] ?? null;
+				}
+				return next;
+			});
+			setCustomColumnError(
+				failures.map((failure) => failure.message).join(" — "),
+			);
+		} else {
+			setCustomColumnError(null);
+		}
+	}, [book.id, customChanges, customColumns, customValues, loadCustomColumns]);
+
 	const hc = useHardcoverBookActions({
 		book,
 		allAuthorNames,
@@ -234,8 +450,10 @@ const EditBookForm = ({
 	});
 
 	const hasChanges = useMemo(
-		() => JSON.stringify(values) !== JSON.stringify(baseline),
-		[values, baseline],
+		() =>
+			JSON.stringify(values) !== JSON.stringify(baseline) ||
+			customChanges.length > 0,
+		[values, baseline, customChanges],
 	);
 
 	const handleAuthorsChange = (next: string[]) => {
@@ -252,6 +470,7 @@ const EditBookForm = ({
 	const revert = () => {
 		setValues(baseline);
 		setIsEditingDescription(false);
+		setCustomValues(customSnapshot);
 	};
 
 	const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -280,6 +499,7 @@ const EditBookForm = ({
 			};
 
 			await onSave(bookUpdate);
+			await saveCustomChanges();
 
 			setBaseline(values);
 		})();
@@ -517,6 +737,57 @@ const EditBookForm = ({
 							</FormRow>
 						</div>
 					</section>
+					{(customColumns.length > 0 || customColumnError) && (
+						<section className={styles.section}>
+							<div className={styles.sectionLabel}>Custom columns</div>
+							<div className={styles.sectionBody}>
+								{customColumnError && (
+									<div
+										role="alert"
+										className={`${styles.notice} ${styles.noticeError}`}
+									>
+										<span className={styles.noticeText}>
+											{customColumnError}
+										</span>
+										<IconButton
+											aria-label="Dismiss"
+											className={styles.noticeClose}
+											onClick={() => setCustomColumnError(null)}
+										>
+											×
+										</IconButton>
+									</div>
+								)}
+								{customColumns.map((column) => {
+									const key = String(column.column_id);
+									const inputId = `edit-book-custom-${key}`;
+									return (
+										<FormRow
+											key={key}
+											label={column.name}
+											htmlFor={inputId}
+											alignTop={
+												column.datatype === "comments" ||
+												(column.datatype === "text" && column.is_multiple)
+											}
+										>
+											<CustomColumnInput
+												id={inputId}
+												column={column}
+												value={customValues[key] ?? emptyFieldValue(column)}
+												onChange={(value) =>
+													setCustomValues((previous) => ({
+														...previous,
+														[key]: value,
+													}))
+												}
+											/>
+										</FormRow>
+									);
+								})}
+							</div>
+						</section>
+					)}
 					{hc.hardcoverApiKey && (
 						<section className={styles.section}>
 							<FormRow label="Hardcover">

--- a/src/lib/custom-columns.test.ts
+++ b/src/lib/custom-columns.test.ts
@@ -1,0 +1,225 @@
+import type { CustomColumnDef } from "@/bindings";
+import { describe, expect, it } from "vitest";
+import {
+	buildCustomFieldValues,
+	diffCustomValues,
+	dtoFromFieldValue,
+	editableCustomColumns,
+	fieldValueFromDto,
+} from "./custom-columns";
+
+const column = (overrides: Partial<CustomColumnDef>): CustomColumnDef => ({
+	column_id: 1,
+	label: "mycolumn",
+	name: "My Column",
+	datatype: "text",
+	is_multiple: false,
+	editable: true,
+	supported: true,
+	enum_values: [],
+	...overrides,
+});
+
+describe("editableCustomColumns", () => {
+	it("keeps only supported, editable columns", () => {
+		const columns = [
+			column({ column_id: 1, label: "rating", supported: false }),
+			column({ column_id: 2, label: "notes", editable: false }),
+			column({ column_id: 3, label: "mood" }),
+		];
+
+		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
+			3,
+		]);
+	});
+
+	it("excludes the read column, which is written through BookUpdate", () => {
+		const columns = [
+			column({ column_id: 1, label: "read", datatype: "bool" }),
+			column({ column_id: 2, label: "mood" }),
+		];
+
+		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
+			2,
+		]);
+	});
+});
+
+describe("fieldValueFromDto", () => {
+	it("maps missing values to the column's empty value", () => {
+		expect(fieldValueFromDto(column({ datatype: "bool" }), null)).toBeNull();
+		expect(fieldValueFromDto(column({ datatype: "int" }), null)).toBe("");
+		expect(fieldValueFromDto(column({ datatype: "text" }), null)).toBe("");
+		expect(
+			fieldValueFromDto(column({ datatype: "text", is_multiple: true }), null),
+		).toEqual([]);
+		expect(
+			fieldValueFromDto(column({ datatype: "enumeration" }), null),
+		).toBeNull();
+	});
+
+	it("maps booleans to yes/no", () => {
+		const bool = column({ datatype: "bool" });
+		expect(fieldValueFromDto(bool, { Bool: true })).toBe("yes");
+		expect(fieldValueFromDto(bool, { Bool: false })).toBe("no");
+	});
+
+	it("maps numbers, text, and lists through unchanged", () => {
+		expect(fieldValueFromDto(column({ datatype: "int" }), { Int: 42 })).toBe(
+			42,
+		);
+		expect(
+			fieldValueFromDto(column({ datatype: "float" }), { Float: 3.5 }),
+		).toBe(3.5);
+		expect(
+			fieldValueFromDto(column({ datatype: "text" }), { Text: "hello" }),
+		).toBe("hello");
+		expect(
+			fieldValueFromDto(column({ datatype: "text", is_multiple: true }), {
+				TextMultiple: ["a", "b"],
+			}),
+		).toEqual(["a", "b"]);
+		expect(
+			fieldValueFromDto(column({ datatype: "enumeration" }), {
+				Enumeration: "good",
+			}),
+		).toBe("good");
+	});
+
+	it("truncates datetimes to date-only for editing", () => {
+		expect(
+			fieldValueFromDto(column({ datatype: "datetime" }), {
+				Datetime: "2024-01-15T10:30:00+00:00",
+			}),
+		).toBe("2024-01-15");
+	});
+});
+
+describe("dtoFromFieldValue", () => {
+	it("maps empty values to null (clear)", () => {
+		expect(dtoFromFieldValue(column({ datatype: "bool" }), null)).toBeNull();
+		expect(dtoFromFieldValue(column({ datatype: "int" }), "")).toBeNull();
+		expect(dtoFromFieldValue(column({ datatype: "float" }), "")).toBeNull();
+		expect(dtoFromFieldValue(column({ datatype: "text" }), "")).toBeNull();
+		expect(
+			dtoFromFieldValue(column({ datatype: "text", is_multiple: true }), []),
+		).toBeNull();
+		expect(dtoFromFieldValue(column({ datatype: "comments" }), "")).toBeNull();
+		expect(
+			dtoFromFieldValue(column({ datatype: "datetime" }), "  "),
+		).toBeNull();
+		expect(
+			dtoFromFieldValue(column({ datatype: "enumeration" }), null),
+		).toBeNull();
+		expect(
+			dtoFromFieldValue(column({ datatype: "enumeration" }), ""),
+		).toBeNull();
+	});
+
+	it("maps yes/no to booleans", () => {
+		const bool = column({ datatype: "bool" });
+		expect(dtoFromFieldValue(bool, "yes")).toEqual({ Bool: true });
+		expect(dtoFromFieldValue(bool, "no")).toEqual({ Bool: false });
+	});
+
+	it("truncates int values and parses in-progress number strings", () => {
+		const int = column({ datatype: "int" });
+		expect(dtoFromFieldValue(int, 7)).toEqual({ Int: 7 });
+		expect(dtoFromFieldValue(int, 7.9)).toEqual({ Int: 7 });
+		expect(dtoFromFieldValue(int, "12")).toEqual({ Int: 12 });
+		expect(dtoFromFieldValue(int, "-")).toBeNull();
+
+		const float = column({ datatype: "float" });
+		expect(dtoFromFieldValue(float, 2.25)).toEqual({ Float: 2.25 });
+		expect(dtoFromFieldValue(float, "2.5")).toEqual({ Float: 2.5 });
+	});
+
+	it("maps text by multiplicity, and comments to Text", () => {
+		expect(dtoFromFieldValue(column({ datatype: "text" }), "hi")).toEqual({
+			Text: "hi",
+		});
+		expect(
+			dtoFromFieldValue(column({ datatype: "text", is_multiple: true }), [
+				"a",
+				"b",
+			]),
+		).toEqual({ TextMultiple: ["a", "b"] });
+		expect(
+			dtoFromFieldValue(column({ datatype: "comments" }), "note"),
+		).toEqual({ Text: "note" });
+	});
+
+	it("sends midnight UTC for date-only datetime input", () => {
+		expect(
+			dtoFromFieldValue(column({ datatype: "datetime" }), "2024-01-15"),
+		).toEqual({ Datetime: "2024-01-15T00:00:00+00:00" });
+	});
+
+	it("passes full datetime strings through for backend validation", () => {
+		expect(
+			dtoFromFieldValue(
+				column({ datatype: "datetime" }),
+				"2024-01-15T10:30:00+00:00",
+			),
+		).toEqual({ Datetime: "2024-01-15T10:30:00+00:00" });
+	});
+
+	it("maps enumeration selections", () => {
+		expect(
+			dtoFromFieldValue(
+				column({ datatype: "enumeration", enum_values: ["good", "bad"] }),
+				"good",
+			),
+		).toEqual({ Enumeration: "good" });
+	});
+});
+
+describe("buildCustomFieldValues", () => {
+	it("keys values by column id and fills gaps with empty values", () => {
+		const columns = [
+			column({ column_id: 1, datatype: "bool" }),
+			column({ column_id: 2, datatype: "text" }),
+		];
+
+		expect(
+			buildCustomFieldValues(columns, [
+				{ column_id: 2, value: { Text: "hello" } },
+			]),
+		).toEqual({ "1": null, "2": "hello" });
+	});
+});
+
+describe("diffCustomValues", () => {
+	const columns = [
+		column({ column_id: 1, datatype: "bool" }),
+		column({ column_id: 2, datatype: "text" }),
+		column({ column_id: 3, datatype: "datetime" }),
+	];
+
+	it("returns only the columns whose effective value changed", () => {
+		const before = { "1": null, "2": "old", "3": "2024-01-15" };
+		const after = { "1": "yes", "2": "old", "3": "2024-01-15" };
+
+		expect(diffCustomValues(columns, before, after)).toEqual([
+			{ columnId: 1, value: { Bool: true } },
+		]);
+	});
+
+	it("emits null when a value is cleared", () => {
+		const before = { "1": "yes", "2": "old", "3": "2024-01-15" };
+		const after = { "1": "yes", "2": "", "3": "2024-01-15" };
+
+		expect(diffCustomValues(columns, before, after)).toEqual([
+			{ columnId: 2, value: null },
+		]);
+	});
+
+	it("treats missing keys as the column's empty value", () => {
+		expect(diffCustomValues(columns, {}, { "1": null, "2": "" })).toEqual([]);
+	});
+
+	it("does not report equivalent number strings as changes", () => {
+		const int = [column({ column_id: 4, datatype: "int" })];
+		expect(diffCustomValues(int, { "4": 12 }, { "4": "12" })).toEqual([]);
+	});
+});

--- a/src/lib/custom-columns.test.ts
+++ b/src/lib/custom-columns.test.ts
@@ -42,9 +42,7 @@ describe("editableCustomColumns", () => {
 			column({ column_id: 3, label: "mood" }),
 		];
 
-		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
-			3,
-		]);
+		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([3]);
 	});
 
 	it("excludes the bool read column, which is written through BookUpdate", () => {
@@ -53,9 +51,7 @@ describe("editableCustomColumns", () => {
 			column({ column_id: 2, label: "mood" }),
 		];
 
-		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
-			2,
-		]);
+		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([2]);
 	});
 
 	it("keeps non-bool columns that happen to be labelled read", () => {
@@ -64,9 +60,7 @@ describe("editableCustomColumns", () => {
 			column({ column_id: 2, label: "read", datatype: "bool" }),
 		];
 
-		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
-			1,
-		]);
+		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([1]);
 	});
 });
 
@@ -177,9 +171,7 @@ describe("dtoFromFieldValue", () => {
 
 	it("rejects number strings with trailing garbage", () => {
 		expect(dtoFromFieldValue(column({ datatype: "int" }), "12abc")).toBeNull();
-		expect(
-			dtoFromFieldValue(column({ datatype: "float" }), "2.5x"),
-		).toBeNull();
+		expect(dtoFromFieldValue(column({ datatype: "float" }), "2.5x")).toBeNull();
 	});
 
 	it("rejects int values outside i32 range", () => {
@@ -202,9 +194,9 @@ describe("dtoFromFieldValue", () => {
 				"b",
 			]),
 		).toEqual({ TextMultiple: ["a", "b"] });
-		expect(
-			dtoFromFieldValue(column({ datatype: "comments" }), "note"),
-		).toEqual({ Text: "note" });
+		expect(dtoFromFieldValue(column({ datatype: "comments" }), "note")).toEqual(
+			{ Text: "note" },
+		);
 	});
 
 	it("sends LOCAL midnight with the local offset for date-only input", () => {
@@ -223,7 +215,10 @@ describe("dtoFromFieldValue", () => {
 	});
 
 	it("writes a local midnight that parses back to the same calendar date", () => {
-		const dto = dtoFromFieldValue(column({ datatype: "datetime" }), "2024-01-15");
+		const dto = dtoFromFieldValue(
+			column({ datatype: "datetime" }),
+			"2024-01-15",
+		);
 		if (dto === null || !("Datetime" in dto)) {
 			throw new Error("expected a Datetime DTO");
 		}
@@ -339,7 +334,9 @@ describe("diffCustomValues", () => {
 				{ "6": "2024-01-15T00:00:00+00:00" },
 				{ "6": "2024-01-16T00:00:00+00:00" },
 			),
-		).toEqual([{ columnId: 6, value: { Datetime: "2024-01-16T00:00:00+00:00" } }]);
+		).toEqual([
+			{ columnId: 6, value: { Datetime: "2024-01-16T00:00:00+00:00" } },
+		]);
 	});
 
 	it("does not write when a stored date round-trips unchanged", () => {

--- a/src/lib/custom-columns.test.ts
+++ b/src/lib/custom-columns.test.ts
@@ -8,6 +8,20 @@ import {
 	fieldValueFromDto,
 } from "./custom-columns";
 
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+/** Local calendar date of an instant, via the same Date APIs the code uses. */
+const localDate = (date: Date) =>
+	`${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+
+/** Local UTC offset (`±HH:MM`) in effect at local midnight of y-m-d. */
+const localOffsetAtMidnight = (year: number, month: number, day: number) => {
+	const minutes = -new Date(year, month - 1, day, 0, 0, 0).getTimezoneOffset();
+	const sign = minutes < 0 ? "-" : "+";
+	const absolute = Math.abs(minutes);
+	return `${sign}${pad2(Math.floor(absolute / 60))}:${pad2(absolute % 60)}`;
+};
+
 const column = (overrides: Partial<CustomColumnDef>): CustomColumnDef => ({
 	column_id: 1,
 	label: "mycolumn",
@@ -33,7 +47,7 @@ describe("editableCustomColumns", () => {
 		]);
 	});
 
-	it("excludes the read column, which is written through BookUpdate", () => {
+	it("excludes the bool read column, which is written through BookUpdate", () => {
 		const columns = [
 			column({ column_id: 1, label: "read", datatype: "bool" }),
 			column({ column_id: 2, label: "mood" }),
@@ -41,6 +55,17 @@ describe("editableCustomColumns", () => {
 
 		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
 			2,
+		]);
+	});
+
+	it("keeps non-bool columns that happen to be labelled read", () => {
+		const columns = [
+			column({ column_id: 1, label: "read", datatype: "datetime" }),
+			column({ column_id: 2, label: "read", datatype: "bool" }),
+		];
+
+		expect(editableCustomColumns(columns).map((c) => c.column_id)).toEqual([
+			1,
 		]);
 	});
 });
@@ -86,12 +111,28 @@ describe("fieldValueFromDto", () => {
 		).toBe("good");
 	});
 
-	it("truncates datetimes to date-only for editing", () => {
+	it("maps datetimes to the LOCAL calendar date for editing", () => {
+		const raw = "2024-01-15T10:30:00+00:00";
+		expect(
+			fieldValueFromDto(column({ datatype: "datetime" }), { Datetime: raw }),
+		).toBe(localDate(new Date(raw)));
+
+		// An instant near the UTC day boundary must land on the local date,
+		// not the UTC one.
+		const nearBoundary = "2024-01-15T00:10:00+00:00";
 		expect(
 			fieldValueFromDto(column({ datatype: "datetime" }), {
-				Datetime: "2024-01-15T10:30:00+00:00",
+				Datetime: nearBoundary,
 			}),
-		).toBe("2024-01-15");
+		).toBe(localDate(new Date(nearBoundary)));
+	});
+
+	it("falls back to the raw string for unparseable datetimes", () => {
+		expect(
+			fieldValueFromDto(column({ datatype: "datetime" }), {
+				Datetime: "not a date",
+			}),
+		).toBe("not a date");
 	});
 });
 
@@ -134,6 +175,23 @@ describe("dtoFromFieldValue", () => {
 		expect(dtoFromFieldValue(float, "2.5")).toEqual({ Float: 2.5 });
 	});
 
+	it("rejects number strings with trailing garbage", () => {
+		expect(dtoFromFieldValue(column({ datatype: "int" }), "12abc")).toBeNull();
+		expect(
+			dtoFromFieldValue(column({ datatype: "float" }), "2.5x"),
+		).toBeNull();
+	});
+
+	it("rejects int values outside i32 range", () => {
+		const int = column({ datatype: "int" });
+		expect(dtoFromFieldValue(int, "2147483648")).toBeNull();
+		expect(dtoFromFieldValue(int, "-2147483649")).toBeNull();
+		expect(dtoFromFieldValue(int, "2147483647")).toEqual({ Int: 2147483647 });
+		expect(dtoFromFieldValue(int, "-2147483648")).toEqual({
+			Int: -2147483648,
+		});
+	});
+
 	it("maps text by multiplicity, and comments to Text", () => {
 		expect(dtoFromFieldValue(column({ datatype: "text" }), "hi")).toEqual({
 			Text: "hi",
@@ -149,10 +207,27 @@ describe("dtoFromFieldValue", () => {
 		).toEqual({ Text: "note" });
 	});
 
-	it("sends midnight UTC for date-only datetime input", () => {
+	it("sends LOCAL midnight with the local offset for date-only input", () => {
 		expect(
 			dtoFromFieldValue(column({ datatype: "datetime" }), "2024-01-15"),
-		).toEqual({ Datetime: "2024-01-15T00:00:00+00:00" });
+		).toEqual({
+			Datetime: `2024-01-15T00:00:00${localOffsetAtMidnight(2024, 1, 15)}`,
+		});
+
+		// DST-safe: the offset is derived from the entered date itself.
+		expect(
+			dtoFromFieldValue(column({ datatype: "datetime" }), "2024-07-15"),
+		).toEqual({
+			Datetime: `2024-07-15T00:00:00${localOffsetAtMidnight(2024, 7, 15)}`,
+		});
+	});
+
+	it("writes a local midnight that parses back to the same calendar date", () => {
+		const dto = dtoFromFieldValue(column({ datatype: "datetime" }), "2024-01-15");
+		if (dto === null || !("Datetime" in dto)) {
+			throw new Error("expected a Datetime DTO");
+		}
+		expect(localDate(new Date(dto.Datetime))).toBe("2024-01-15");
 	});
 
 	it("passes full datetime strings through for backend validation", () => {
@@ -221,5 +296,64 @@ describe("diffCustomValues", () => {
 	it("does not report equivalent number strings as changes", () => {
 		const int = [column({ column_id: 4, datatype: "int" })];
 		expect(diffCustomValues(int, { "4": 12 }, { "4": "12" })).toEqual([]);
+	});
+
+	it("treats unusable number input as no change, never as clear", () => {
+		const int = [column({ column_id: 4, datatype: "int" })];
+		// Trailing garbage: no write
+		expect(diffCustomValues(int, { "4": 5 }, { "4": "12abc" })).toEqual([]);
+		// Out-of-range int: no write
+		expect(diffCustomValues(int, { "4": 5 }, { "4": "2147483648" })).toEqual(
+			[],
+		);
+		// Empty string: explicit clear
+		expect(diffCustomValues(int, { "4": 5 }, { "4": "" })).toEqual([
+			{ columnId: 4, value: null },
+		]);
+		// Valid input: write
+		expect(diffCustomValues(int, { "4": 5 }, { "4": "12" })).toEqual([
+			{ columnId: 4, value: { Int: 12 } },
+		]);
+
+		const float = [column({ column_id: 5, datatype: "float" })];
+		expect(diffCustomValues(float, { "5": 1.5 }, { "5": "2.5x" })).toEqual([]);
+		expect(diffCustomValues(float, { "5": 1.5 }, { "5": "2.5" })).toEqual([
+			{ columnId: 5, value: { Float: 2.5 } },
+		]);
+	});
+
+	it("compares datetimes by instant, not by string", () => {
+		const dt = [column({ column_id: 6, datatype: "datetime" })];
+		// Same instant spelled with different offsets: no change.
+		expect(
+			diffCustomValues(
+				dt,
+				{ "6": "2024-01-15T00:00:00+00:00" },
+				{ "6": "2024-01-15T01:00:00+01:00" },
+			),
+		).toEqual([]);
+		// Different instants: a change.
+		expect(
+			diffCustomValues(
+				dt,
+				{ "6": "2024-01-15T00:00:00+00:00" },
+				{ "6": "2024-01-16T00:00:00+00:00" },
+			),
+		).toEqual([{ columnId: 6, value: { Datetime: "2024-01-16T00:00:00+00:00" } }]);
+	});
+
+	it("does not write when a stored date round-trips unchanged", () => {
+		const dtColumn = column({ column_id: 6, datatype: "datetime" });
+		// A previously saved local-midnight value comes back from the backend…
+		const stored = dtoFromFieldValue(dtColumn, "2024-01-15");
+		if (stored === null || !("Datetime" in stored)) {
+			throw new Error("expected a Datetime DTO");
+		}
+		// …is rendered as a local date, and saved again without edits.
+		const field = fieldValueFromDto(dtColumn, stored);
+		expect(field).toBe("2024-01-15");
+		expect(
+			diffCustomValues([dtColumn], { "6": field }, { "6": field }),
+		).toEqual([]);
 	});
 });

--- a/src/lib/custom-columns.ts
+++ b/src/lib/custom-columns.ts
@@ -26,7 +26,7 @@ export const editableCustomColumns = (
 		(column) =>
 			column.supported &&
 			column.editable &&
-			column.label !== READ_COLUMN_LABEL,
+			!(column.label === READ_COLUMN_LABEL && column.datatype === "bool"),
 	);
 
 /** The form value representing "no value stored" for a column. */
@@ -69,21 +69,96 @@ export const fieldValueFromDto = (
 		return value.TextMultiple;
 	}
 	if ("Datetime" in value) {
-		// Edit at date-only granularity.
-		return value.Datetime.slice(0, 10);
+		// Edit at date-only granularity, in the user's local calendar.
+		return localDateOfInstant(value.Datetime) ?? value.Datetime;
 	}
 	return value.Enumeration;
 };
 
-const numberFieldToValue = (value: string | number): number | null => {
-	if (typeof value === "number") {
-		return Number.isFinite(value) ? value : null;
+const pad2 = (n: number): string => String(n).padStart(2, "0");
+
+/**
+ * The LOCAL calendar date (`YYYY-MM-DD`) of an RFC3339 instant, or `null`
+ * when the string cannot be parsed.
+ */
+export const localDateOfInstant = (rfc3339: string): string | null => {
+	const parsed = new Date(rfc3339);
+	if (Number.isNaN(parsed.getTime())) {
+		return null;
 	}
-	const parsed = Number.parseFloat(value);
-	return Number.isFinite(parsed) ? parsed : null;
+	return `${parsed.getFullYear()}-${pad2(parsed.getMonth() + 1)}-${pad2(
+		parsed.getDate(),
+	)}`;
+};
+
+const I32_MIN = -2147483648;
+const I32_MAX = 2147483647;
+
+/**
+ * Parse a NumberInput value. Uses `Number()` semantics, so trailing garbage
+ * (`"12abc"`) is rejected rather than truncated. For int columns, values
+ * outside i32 range are rejected. `null` means "not a usable number"; callers
+ * must treat that as "no change", never as "clear".
+ */
+const numberFieldToValue = (
+	value: string | number,
+	isInt: boolean,
+): number | null => {
+	const parsed = typeof value === "number" ? value : Number(value.trim());
+	if (!Number.isFinite(parsed)) {
+		return null;
+	}
+	if (isInt) {
+		const truncated = Math.trunc(parsed);
+		return truncated >= I32_MIN && truncated <= I32_MAX ? truncated : null;
+	}
+	return parsed;
+};
+
+/**
+ * Whether a form value for an int/float column is non-empty but not a usable
+ * number (junk text, out-of-range int). Such input must not be written — and
+ * in particular must not clear the stored value.
+ */
+const isUnusableNumberInput = (
+	column: CustomColumnDef,
+	value: CustomFieldValue,
+): boolean => {
+	if (column.datatype !== "int" && column.datatype !== "float") {
+		return false;
+	}
+	if (value === null || Array.isArray(value)) {
+		return false;
+	}
+	if (typeof value === "string" && value.trim() === "") {
+		return false; // empty = clear, which is fine
+	}
+	return numberFieldToValue(value, column.datatype === "int") === null;
 };
 
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * RFC3339 string for the LOCAL midnight of a `YYYY-MM-DD` date, carrying the
+ * local UTC offset in effect on that date (DST-safe), matching Calibre's
+ * local-midnight-with-offset semantics. `null` when the input is not a
+ * date-only string.
+ */
+export const localMidnightRfc3339 = (date: string): string | null => {
+	if (!DATE_ONLY_PATTERN.test(date)) {
+		return null;
+	}
+	const year = Number(date.slice(0, 4));
+	const month = Number(date.slice(5, 7));
+	const day = Number(date.slice(8, 10));
+	const midnight = new Date(year, month - 1, day, 0, 0, 0);
+	// getTimezoneOffset() is minutes BEHIND UTC (e.g. 480 for UTC-8).
+	const offsetMinutes = -midnight.getTimezoneOffset();
+	const sign = offsetMinutes < 0 ? "-" : "+";
+	const absolute = Math.abs(offsetMinutes);
+	const offset = `${sign}${pad2(Math.floor(absolute / 60))}:${pad2(absolute % 60)}`;
+	return `${date}T00:00:00${offset}`;
+};
 
 /**
  * Convert a form field value into the DTO to send to the backend.
@@ -100,13 +175,15 @@ export const dtoFromFieldValue = (
 			return null;
 		}
 		case "int": {
-			if (value === null || value === "" || Array.isArray(value)) return null;
-			const parsed = numberFieldToValue(value);
-			return parsed === null ? null : { Int: Math.trunc(parsed) };
+			if (value === null || Array.isArray(value)) return null;
+			if (typeof value === "string" && value.trim() === "") return null;
+			const parsed = numberFieldToValue(value, true);
+			return parsed === null ? null : { Int: parsed };
 		}
 		case "float": {
-			if (value === null || value === "" || Array.isArray(value)) return null;
-			const parsed = numberFieldToValue(value);
+			if (value === null || Array.isArray(value)) return null;
+			if (typeof value === "string" && value.trim() === "") return null;
+			const parsed = numberFieldToValue(value, false);
 			return parsed === null ? null : { Float: parsed };
 		}
 		case "text": {
@@ -128,9 +205,10 @@ export const dtoFromFieldValue = (
 			if (typeof value !== "string") return null;
 			const trimmed = value.trim();
 			if (trimmed === "") return null;
-			if (DATE_ONLY_PATTERN.test(trimmed)) {
-				// Date-only input: send midnight UTC.
-				return { Datetime: `${trimmed}T00:00:00+00:00` };
+			// Date-only input: send local midnight with the local UTC offset.
+			const localMidnight = localMidnightRfc3339(trimmed);
+			if (localMidnight !== null) {
+				return { Datetime: localMidnight };
 			}
 			// Pass through; the backend rejects strings that are not RFC3339.
 			return { Datetime: trimmed };
@@ -167,8 +245,36 @@ export interface CustomValueChange {
 }
 
 /**
+ * Compare two datetime strings by the instant they denote, so a round-tripped
+ * unchanged date (e.g. re-serialized with a different offset) is not reported
+ * as a change. Falls back to string equality when either side fails to parse.
+ */
+const datetimesEqual = (a: string, b: string): boolean => {
+	const aMs = new Date(a).getTime();
+	const bMs = new Date(b).getTime();
+	if (Number.isNaN(aMs) || Number.isNaN(bMs)) {
+		return a === b;
+	}
+	return aMs === bMs;
+};
+
+const dtosEqual = (
+	a: CustomValueDto | null,
+	b: CustomValueDto | null,
+): boolean => {
+	if (a !== null && b !== null && "Datetime" in a && "Datetime" in b) {
+		return datetimesEqual(a.Datetime, b.Datetime);
+	}
+	return JSON.stringify(a) === JSON.stringify(b);
+};
+
+/**
  * The set of columns whose effective value differs between two form
  * snapshots, with the DTO to write for each.
+ *
+ * Columns whose `after` value is unusable number input (junk text,
+ * out-of-range int) are treated as unchanged: a junk paste must not silently
+ * clear a stored value.
  */
 export const diffCustomValues = (
 	columns: CustomColumnDef[],
@@ -178,15 +284,16 @@ export const diffCustomValues = (
 	const changes: CustomValueChange[] = [];
 	for (const column of columns) {
 		const key = String(column.column_id);
+		const afterValue = after[key] ?? emptyFieldValue(column);
+		if (isUnusableNumberInput(column, afterValue)) {
+			continue;
+		}
 		const beforeDto = dtoFromFieldValue(
 			column,
 			before[key] ?? emptyFieldValue(column),
 		);
-		const afterDto = dtoFromFieldValue(
-			column,
-			after[key] ?? emptyFieldValue(column),
-		);
-		if (JSON.stringify(beforeDto) !== JSON.stringify(afterDto)) {
+		const afterDto = dtoFromFieldValue(column, afterValue);
+		if (!dtosEqual(beforeDto, afterDto)) {
 			changes.push({ columnId: column.column_id, value: afterDto });
 		}
 	}

--- a/src/lib/custom-columns.ts
+++ b/src/lib/custom-columns.ts
@@ -1,0 +1,194 @@
+import type { BookCustomValue, CustomColumnDef, CustomValueDto } from "@/bindings";
+
+/**
+ * The label of the Calibre custom column backing the "Finished" switch.
+ * It is already written through `BookUpdate.is_read`, so the custom-column
+ * editor must not render (and double-write) it.
+ */
+export const READ_COLUMN_LABEL = "read";
+
+/**
+ * A custom-column value as held in the edit form.
+ *
+ * - bool: `null` (unset) | `"yes"` | `"no"`
+ * - int/float: `""` (unset) | number (or an in-progress string from NumberInput)
+ * - text/comments/datetime: string (`""` = unset)
+ * - text with is_multiple: string[] (`[]` = unset)
+ * - enumeration: `null` or `""` (unset) | one of `enum_values`
+ */
+export type CustomFieldValue = string | number | string[] | null;
+
+/** Columns the editor should render inputs for. */
+export const editableCustomColumns = (
+	columns: CustomColumnDef[],
+): CustomColumnDef[] =>
+	columns.filter(
+		(column) =>
+			column.supported &&
+			column.editable &&
+			column.label !== READ_COLUMN_LABEL,
+	);
+
+/** The form value representing "no value stored" for a column. */
+export const emptyFieldValue = (column: CustomColumnDef): CustomFieldValue => {
+	switch (column.datatype) {
+		case "bool":
+		case "enumeration":
+			return null;
+		case "text":
+			return column.is_multiple ? [] : "";
+		case "int":
+		case "float":
+			return "";
+		default:
+			return "";
+	}
+};
+
+/** Convert a value DTO from the backend into a form field value. */
+export const fieldValueFromDto = (
+	column: CustomColumnDef,
+	value: CustomValueDto | null,
+): CustomFieldValue => {
+	if (value === null) {
+		return emptyFieldValue(column);
+	}
+	if ("Bool" in value) {
+		return value.Bool ? "yes" : "no";
+	}
+	if ("Int" in value) {
+		return value.Int;
+	}
+	if ("Float" in value) {
+		return value.Float;
+	}
+	if ("Text" in value) {
+		return value.Text;
+	}
+	if ("TextMultiple" in value) {
+		return value.TextMultiple;
+	}
+	if ("Datetime" in value) {
+		// Edit at date-only granularity.
+		return value.Datetime.slice(0, 10);
+	}
+	return value.Enumeration;
+};
+
+const numberFieldToValue = (value: string | number): number | null => {
+	if (typeof value === "number") {
+		return Number.isFinite(value) ? value : null;
+	}
+	const parsed = Number.parseFloat(value);
+	return Number.isFinite(parsed) ? parsed : null;
+};
+
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Convert a form field value into the DTO to send to the backend.
+ * `null` means "clear the stored value".
+ */
+export const dtoFromFieldValue = (
+	column: CustomColumnDef,
+	value: CustomFieldValue,
+): CustomValueDto | null => {
+	switch (column.datatype) {
+		case "bool": {
+			if (value === "yes") return { Bool: true };
+			if (value === "no") return { Bool: false };
+			return null;
+		}
+		case "int": {
+			if (value === null || value === "" || Array.isArray(value)) return null;
+			const parsed = numberFieldToValue(value);
+			return parsed === null ? null : { Int: Math.trunc(parsed) };
+		}
+		case "float": {
+			if (value === null || value === "" || Array.isArray(value)) return null;
+			const parsed = numberFieldToValue(value);
+			return parsed === null ? null : { Float: parsed };
+		}
+		case "text": {
+			if (column.is_multiple) {
+				return Array.isArray(value) && value.length > 0
+					? { TextMultiple: value }
+					: null;
+			}
+			return typeof value === "string" && value !== ""
+				? { Text: value }
+				: null;
+		}
+		case "comments": {
+			return typeof value === "string" && value !== ""
+				? { Text: value }
+				: null;
+		}
+		case "datetime": {
+			if (typeof value !== "string") return null;
+			const trimmed = value.trim();
+			if (trimmed === "") return null;
+			if (DATE_ONLY_PATTERN.test(trimmed)) {
+				// Date-only input: send midnight UTC.
+				return { Datetime: `${trimmed}T00:00:00+00:00` };
+			}
+			// Pass through; the backend rejects strings that are not RFC3339.
+			return { Datetime: trimmed };
+		}
+		case "enumeration": {
+			return typeof value === "string" && value !== ""
+				? { Enumeration: value }
+				: null;
+		}
+		default:
+			return null;
+	}
+};
+
+/** Form field values for the given columns, keyed by column id. */
+export const buildCustomFieldValues = (
+	columns: CustomColumnDef[],
+	values: BookCustomValue[],
+): Record<string, CustomFieldValue> => {
+	const valueByColumnId = new Map(
+		values.map((bookValue) => [bookValue.column_id, bookValue.value]),
+	);
+	return Object.fromEntries(
+		columns.map((column) => [
+			String(column.column_id),
+			fieldValueFromDto(column, valueByColumnId.get(column.column_id) ?? null),
+		]),
+	);
+};
+
+export interface CustomValueChange {
+	columnId: number;
+	value: CustomValueDto | null;
+}
+
+/**
+ * The set of columns whose effective value differs between two form
+ * snapshots, with the DTO to write for each.
+ */
+export const diffCustomValues = (
+	columns: CustomColumnDef[],
+	before: Record<string, CustomFieldValue>,
+	after: Record<string, CustomFieldValue>,
+): CustomValueChange[] => {
+	const changes: CustomValueChange[] = [];
+	for (const column of columns) {
+		const key = String(column.column_id);
+		const beforeDto = dtoFromFieldValue(
+			column,
+			before[key] ?? emptyFieldValue(column),
+		);
+		const afterDto = dtoFromFieldValue(
+			column,
+			after[key] ?? emptyFieldValue(column),
+		);
+		if (JSON.stringify(beforeDto) !== JSON.stringify(afterDto)) {
+			changes.push({ columnId: column.column_id, value: afterDto });
+		}
+	}
+	return changes;
+};

--- a/src/lib/custom-columns.ts
+++ b/src/lib/custom-columns.ts
@@ -1,4 +1,8 @@
-import type { BookCustomValue, CustomColumnDef, CustomValueDto } from "@/bindings";
+import type {
+	BookCustomValue,
+	CustomColumnDef,
+	CustomValueDto,
+} from "@/bindings";
 
 /**
  * The label of the Calibre custom column backing the "Finished" switch.
@@ -192,14 +196,10 @@ export const dtoFromFieldValue = (
 					? { TextMultiple: value }
 					: null;
 			}
-			return typeof value === "string" && value !== ""
-				? { Text: value }
-				: null;
+			return typeof value === "string" && value !== "" ? { Text: value } : null;
 		}
 		case "comments": {
-			return typeof value === "string" && value !== ""
-				? { Text: value }
-				: null;
+			return typeof value === "string" && value !== "" ? { Text: value } : null;
 		}
 		case "datetime": {
 			if (typeof value !== "string") return null;


### PR DESCRIPTION
Calibre custom columns (reading status, scores, formats owned, …) are now first-class in Citadel: enumerable, readable, and writable for bool, int, float, text (single and multiple), comments, datetime, and enumeration datatypes — using Calibre's on-disk layout (`custom_column_{id}` value tables and `books_custom_column_{id}_link` link tables for normalized types), so Calibre reads what we write.

## What's here

- **libcalibre**: a generic `custom_columns` module — enumerate columns with label/name/datatype, typed get/set/clear per book, batch reads, and dynamic table creation matching Calibre's. The old hardcoded read-state API (`get_book_read_state` etc.) is reimplemented on top of it.
- **Tauri commands**: `clb_query_list_custom_columns`, `clb_query_get_custom_values_for_book`, `clb_cmd_set_custom_value`, with a `CustomValueDto` boundary type (bindings.ts hand-synced).
- **Edit Book UI**: a "Custom columns" section rendering a typed input per column (pop-up for bool/enumeration, token field for multi-text, etc.), with snapshot-based dirty tracking, save alongside the regular form, and revert. The `read` bool column is excluded since the Finished switch already owns it.
- **Calibre fidelity details**: empty text clears instead of storing `""`; datetimes are edited as local calendar dates and stored as local midnight with UTC offset (DST-safe), matching Calibre's semantics; junk or out-of-i32-range numeric input is rejected rather than truncated or treated as a clear.

## Tests

22 libcalibre integration tests (including a raw-SQL fixture asserting the exact on-disk format Calibre expects), 3 DTO round-trip unit tests, 26 vitest cases for the form-value mapping. `cargo test --workspace`, `bunx tsc --noEmit`, biome, and vitest all pass.

Fixes CDL-1
Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)