### PR TITLE
feat(libcalibre): SQL-backed book search (CDL-3)

### DIFF
--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -675,8 +675,34 @@ impl Library {
     // Search
     // =========================================================================
 
-    pub fn search_books(&mut self, _query: &str) -> Result<Vec<Book>, CalibreError> {
-        todo!()
+    pub fn search_books(&mut self, query: &str) -> Result<Vec<Book>, CalibreError> {
+        let query = query.trim();
+        if query.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let book_ids = book_queries::search(&mut self.conn, query)?;
+        self.get_books_with_read_states(book_ids)
+    }
+
+    pub fn find_by_author(&mut self, author_id: AuthorId) -> Result<Vec<Book>, CalibreError> {
+        let book_ids = book_queries::find_by_author(&mut self.conn, author_id)?;
+        self.get_books_with_read_states(book_ids)
+    }
+
+    fn get_books_with_read_states(
+        &mut self,
+        book_ids: Vec<BookId>,
+    ) -> Result<Vec<Book>, CalibreError> {
+        let mut books = operations::books::get_many(&mut self.conn, book_ids)?;
+
+        let book_ids: Vec<BookId> = books.iter().map(|b| b.id).collect();
+        let read_states = self.batch_get_read_states(&book_ids)?;
+        for book in &mut books {
+            book.is_read = read_states.get(&book.id).copied().unwrap_or(false);
+        }
+
+        Ok(books)
     }
 }
 

--- a/crates/libcalibre/src/operations/books.rs
+++ b/crates/libcalibre/src/operations/books.rs
@@ -7,7 +7,7 @@ use crate::{
     library::{Book, BookFileInfo, BookIdentifier, BookUpdate},
     queries::{authors, book_descriptions, book_files, book_identifiers, books, series, tags},
     types::{AuthorId, BookId},
-    CalibreError, UpdateBookData,
+    BookRow, CalibreError, UpdateBookData,
 };
 
 pub fn update_book(
@@ -222,6 +222,29 @@ pub fn get_book(conn: &mut SqliteConnection, book_id: BookId) -> Result<Book, Ca
 
 pub fn all(conn: &mut SqliteConnection) -> Result<Vec<Book>, CalibreError> {
     let book_rows = books::all(conn)?;
+    hydrate(conn, book_rows)
+}
+
+pub fn get_many(
+    conn: &mut SqliteConnection,
+    book_ids: Vec<BookId>,
+) -> Result<Vec<Book>, CalibreError> {
+    let mut book_rows = books::get_by_ids(conn, book_ids.clone())?;
+
+    let positions: HashMap<i32, usize> = book_ids
+        .iter()
+        .enumerate()
+        .map(|(position, id)| (id.as_i32(), position))
+        .collect();
+    book_rows.sort_by_key(|row| positions.get(&row.id).copied().unwrap_or(usize::MAX));
+
+    hydrate(conn, book_rows)
+}
+
+fn hydrate(
+    conn: &mut SqliteConnection,
+    book_rows: Vec<BookRow>,
+) -> Result<Vec<Book>, CalibreError> {
     let book_ids: Vec<BookId> = book_rows.iter().map(|b| BookId(b.id)).collect();
 
     let author_ids_by_book = authors::find_author_ids_by_book_ids(conn, book_ids.clone())?;

--- a/crates/libcalibre/src/queries/books.rs
+++ b/crates/libcalibre/src/queries/books.rs
@@ -4,7 +4,8 @@
 //! All functions use type-safe IDs and accept a mutable SQLite connection.
 
 use diesel::prelude::*;
-use diesel::{QueryDsl, RunQueryDsl, SqliteConnection};
+use diesel::sql_types::{Integer, Text};
+use diesel::{sql_query, QueryDsl, QueryableByName, RunQueryDsl, SqliteConnection};
 
 use crate::types::AuthorId;
 use crate::{types::BookId, CalibreError};
@@ -35,6 +36,56 @@ pub(crate) fn all(conn: &mut SqliteConnection) -> Result<Vec<BookRow>, CalibreEr
         .select(BookRow::as_select())
         .load(conn)
         .map_err(CalibreError::from)
+}
+
+pub(crate) fn get_by_ids(
+    conn: &mut SqliteConnection,
+    book_ids: Vec<BookId>,
+) -> Result<Vec<BookRow>, CalibreError> {
+    use crate::schema::books::dsl::*;
+
+    let raw_ids: Vec<i32> = book_ids.iter().map(BookId::as_i32).collect();
+
+    books
+        .filter(id.eq_any(raw_ids))
+        .select(BookRow::as_select())
+        .load(conn)
+        .map_err(CalibreError::from)
+}
+
+pub(crate) fn search(
+    conn: &mut SqliteConnection,
+    query: &str,
+) -> Result<Vec<BookId>, CalibreError> {
+    #[derive(QueryableByName)]
+    struct MatchedBook {
+        #[diesel(sql_type = Integer)]
+        id: i32,
+    }
+
+    let escaped = query
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_");
+    let pattern = format!("%{escaped}%");
+
+    let matches: Vec<MatchedBook> = sql_query(
+        "SELECT DISTINCT books.id FROM books \
+         LEFT JOIN books_authors_link ON books_authors_link.book = books.id \
+         LEFT JOIN authors ON authors.id = books_authors_link.author \
+         LEFT JOIN books_series_link ON books_series_link.book = books.id \
+         LEFT JOIN series ON series.id = books_series_link.series \
+         WHERE books.title LIKE ? ESCAPE '\\' \
+            OR authors.name LIKE ? ESCAPE '\\' \
+            OR series.name LIKE ? ESCAPE '\\'",
+    )
+    .bind::<Text, _>(&pattern)
+    .bind::<Text, _>(&pattern)
+    .bind::<Text, _>(&pattern)
+    .load(conn)
+    .map_err(CalibreError::from)?;
+
+    Ok(matches.into_iter().map(|m| BookId(m.id)).collect())
 }
 
 pub(crate) fn create(conn: &mut SqliteConnection, book: NewBook) -> Result<BookRow, CalibreError> {
@@ -87,4 +138,18 @@ pub(crate) fn find_authors(
         .map_err(CalibreError::from)?;
 
     Ok(author_ids)
+}
+
+pub(crate) fn find_by_author(
+    conn: &mut SqliteConnection,
+    author_id: AuthorId,
+) -> Result<Vec<BookId>, CalibreError> {
+    use crate::schema::books_authors_link::dsl::*;
+
+    books_authors_link
+        .filter(author.eq(author_id.as_i32()))
+        .select(book)
+        .load(conn)
+        .map(|ids: Vec<i32>| ids.into_iter().map(BookId).collect())
+        .map_err(CalibreError::from)
 }

--- a/crates/libcalibre/tests/search_test.rs
+++ b/crates/libcalibre/tests/search_test.rs
@@ -1,0 +1,157 @@
+// Tests for Library search and author lookup
+mod common;
+
+use common::setup_with_library;
+use diesel::sql_types::{Integer, Text};
+use diesel::RunQueryDsl;
+use libcalibre::{BookAdd, BookId, Library};
+use std::collections::HashMap;
+
+fn book_with_authors(title: &str, author_names: &[&str]) -> BookAdd {
+    BookAdd {
+        title: title.to_string(),
+        author_names: author_names.iter().map(|n| (*n).to_string()).collect(),
+        tags: None,
+        series: None,
+        series_index: None,
+        publisher: None,
+        publication_date: None,
+        rating: None,
+        comments: None,
+        identifiers: HashMap::new(),
+        file_paths: vec![],
+    }
+}
+
+fn link_series(lib: &Library, book_id: BookId, series_name: &str) {
+    let mut conn = libcalibre::persistence::establish_connection(lib.database_path()).unwrap();
+    diesel::sql_query("INSERT INTO series (name, sort) VALUES (?, ?)")
+        .bind::<Text, _>(series_name)
+        .bind::<Text, _>(series_name)
+        .execute(&mut conn)
+        .unwrap();
+    diesel::sql_query(
+        "INSERT INTO books_series_link (book, series) \
+         SELECT ?, id FROM series WHERE name = ?",
+    )
+    .bind::<Integer, _>(book_id.as_i32())
+    .bind::<Text, _>(series_name)
+    .execute(&mut conn)
+    .unwrap();
+}
+
+#[test]
+fn test_search_title_substring_case_insensitive() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book_with_authors("The Rust Programming Language", &[]))
+        .unwrap();
+    lib.add_book(book_with_authors("Cooking for Two", &[]))
+        .unwrap();
+
+    let results = lib.search_books("rust").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].title, "The Rust Programming Language");
+}
+
+#[test]
+fn test_search_author_name() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book_with_authors("Pride and Prejudice", &["Jane Austen"]))
+        .unwrap();
+    lib.add_book(book_with_authors("Moby Dick", &["Herman Melville"]))
+        .unwrap();
+
+    let results = lib.search_books("austen").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].title, "Pride and Prejudice");
+}
+
+#[test]
+fn test_search_series_name() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let in_series = lib
+        .add_book(book_with_authors("The Fellowship of the Ring", &[]))
+        .unwrap();
+    lib.add_book(book_with_authors("Unrelated Book", &[]))
+        .unwrap();
+
+    link_series(&lib, in_series.id, "The Lord of the Rings");
+
+    let results = lib.search_books("lord of the rings").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, in_series.id);
+}
+
+#[test]
+fn test_search_no_match_returns_empty() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book_with_authors("Book One", &["Author One"]))
+        .unwrap();
+    lib.add_book(book_with_authors("Book Two", &["Author Two"]))
+        .unwrap();
+
+    let results = lib.search_books("xyzzy").unwrap();
+    assert!(results.is_empty());
+}
+
+#[test]
+fn test_search_escapes_like_wildcards() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book_with_authors("100% Done", &[])).unwrap();
+    lib.add_book(book_with_authors("Another Book", &[]))
+        .unwrap();
+
+    let results = lib.search_books("100%").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].title, "100% Done");
+
+    let results = lib.search_books("z%y").unwrap();
+    assert!(results.is_empty());
+
+    let results = lib.search_books("0% D").unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].title, "100% Done");
+}
+
+#[test]
+fn test_search_empty_or_whitespace_query_returns_empty() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book_with_authors("Book One", &[])).unwrap();
+
+    assert!(lib.search_books("").unwrap().is_empty());
+    assert!(lib.search_books("   \t\n").unwrap().is_empty());
+}
+
+#[test]
+fn test_find_by_author() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let first = lib
+        .add_book(book_with_authors("Emma", &["Jane Austen"]))
+        .unwrap();
+    let second = lib
+        .add_book(book_with_authors("Persuasion", &["Jane Austen"]))
+        .unwrap();
+    lib.add_book(book_with_authors("Moby Dick", &["Herman Melville"]))
+        .unwrap();
+
+    let austen_id = first.authors[0].id;
+    assert_eq!(second.authors[0].id, austen_id);
+
+    let mut results = lib.find_by_author(austen_id).unwrap();
+    results.sort_by_key(|b| b.id.as_i32());
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].title, "Emma");
+    assert_eq!(results[1].title, "Persuasion");
+    for book in &results {
+        assert_eq!(book.authors.len(), 1);
+        assert_eq!(book.authors[0].name, "Jane Austen");
+    }
+}

--- a/crates/libcalibre/tests/search_test.rs
+++ b/crates/libcalibre/tests/search_test.rs
@@ -2,9 +2,7 @@
 mod common;
 
 use common::setup_with_library;
-use diesel::sql_types::{Integer, Text};
-use diesel::RunQueryDsl;
-use libcalibre::{BookAdd, BookId, Library};
+use libcalibre::BookAdd;
 use std::collections::HashMap;
 
 fn book_with_authors(title: &str, author_names: &[&str]) -> BookAdd {
@@ -21,23 +19,6 @@ fn book_with_authors(title: &str, author_names: &[&str]) -> BookAdd {
         identifiers: HashMap::new(),
         file_paths: vec![],
     }
-}
-
-fn link_series(lib: &Library, book_id: BookId, series_name: &str) {
-    let mut conn = libcalibre::persistence::establish_connection(lib.database_path()).unwrap();
-    diesel::sql_query("INSERT INTO series (name, sort) VALUES (?, ?)")
-        .bind::<Text, _>(series_name)
-        .bind::<Text, _>(series_name)
-        .execute(&mut conn)
-        .unwrap();
-    diesel::sql_query(
-        "INSERT INTO books_series_link (book, series) \
-         SELECT ?, id FROM series WHERE name = ?",
-    )
-    .bind::<Integer, _>(book_id.as_i32())
-    .bind::<Text, _>(series_name)
-    .execute(&mut conn)
-    .unwrap();
 }
 
 #[test]
@@ -73,12 +54,14 @@ fn test_search_series_name() {
     let (_temp, mut lib) = setup_with_library();
 
     let in_series = lib
-        .add_book(book_with_authors("The Fellowship of the Ring", &[]))
+        .add_book(BookAdd {
+            series: Some("The Lord of the Rings".to_string()),
+            series_index: Some(1.0),
+            ..book_with_authors("The Fellowship of the Ring", &[])
+        })
         .unwrap();
     lib.add_book(book_with_authors("Unrelated Book", &[]))
         .unwrap();
-
-    link_series(&lib, in_series.id, "The Lord of the Rings");
 
     let results = lib.search_books("lord of the rings").unwrap();
     assert_eq!(results.len(), 1);

--- a/crates/libcalibre/tests/search_test.rs
+++ b/crates/libcalibre/tests/search_test.rs
@@ -1,4 +1,6 @@
 // Tests for Library search and author lookup
+// This binary uses only a subset of the shared test helpers.
+#[allow(dead_code, unused_imports)]
 mod common;
 
 use common::setup_with_library;

--- a/src-tauri/src/libs/calibre/book.rs
+++ b/src-tauri/src/libs/calibre/book.rs
@@ -33,6 +33,12 @@ fn book_cover_image(
     }
 }
 
+fn to_library_book(library_root: &str, book: &libcalibre::library::Book) -> LibraryBook {
+    let mut library_book = LibraryBook::from_library_book(book, library_root);
+    library_book.cover_image = book_cover_image(library_root, book);
+    library_book
+}
+
 pub fn list_all(
     library_root: String,
     lib: &mut Library,
@@ -41,10 +47,19 @@ pub fn list_all(
 
     Ok(results
         .iter()
-        .map(|book| {
-            let mut library_book = LibraryBook::from_library_book(book, &library_root);
-            library_book.cover_image = book_cover_image(&library_root, book);
-            library_book
-        })
+        .map(|book| to_library_book(&library_root, book))
+        .collect())
+}
+
+pub fn search(
+    library_root: String,
+    lib: &mut Library,
+    query: &str,
+) -> Result<Vec<LibraryBook>, libcalibre::CalibreError> {
+    let results = lib.search_books(query)?;
+
+    Ok(results
+        .iter()
+        .map(|book| to_library_book(&library_root, book))
         .collect())
 }

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -25,6 +25,20 @@ pub fn clb_query_list_all_books(
 
 #[tauri::command]
 #[specta::specta]
+pub fn clb_query_search_books(
+    state: tauri::State<CitadelState>,
+    query: String,
+) -> Result<Vec<LibraryBook>, String> {
+    let library_root = state
+        .get_library_path()
+        .ok_or("No library loaded".to_string())?;
+
+    let books = state.with_library(|lib| book::search(library_root, lib, &query))?;
+    books.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub fn clb_query_list_all_authors(
     state: tauri::State<CitadelState>,
 ) -> Result<Vec<LibraryAuthor>, String> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,6 +26,7 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::command::clb_cmd_create_library,
         // Book query commands
         calibre::query::clb_query_list_all_books,
+        calibre::query::clb_query_search_books,
         calibre::query::clb_query_is_file_importable,
         calibre::query::clb_query_importable_file_metadata,
         calibre::query::clb_query_list_all_filetypes,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -32,6 +32,14 @@ async clbQueryListAllBooks() : Promise<Result<LibraryBook[], string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async clbQuerySearchBooks(query: string) : Promise<Result<LibraryBook[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_search_books", { query }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbQueryIsFileImportable(pathToFile: string) : Promise<ImportableFile | null> {
     return await TAURI_INVOKE("clb_query_is_file_importable", { pathToFile });
 },


### PR DESCRIPTION
Implements book search in libcalibre and exposes it to the frontend as a Tauri command. Backend + bindings only — no frontend behavior changes.

## Changes

- **`Library::search_books(query)`**: single SQL query joining `books`/`books_authors_link`/`authors`/`books_series_link`/`series`, matching case-insensitive substrings of title, author name, or series name. LIKE wildcards (`%`, `_`, `\`) are escaped; empty/whitespace queries return no results.
- **`Library::find_by_author(author_id)`**: list all books linked to an author.
- **`operations::books::get_many`**: hydrates an arbitrary subset of book IDs (shared `hydrate` path with `all`), preserving the requested ID order.
- **Tauri**: new `clb_query_search_books` command (`src-tauri/src/libs/calibre/query.rs`), registered in `collect_commands`, with hand-edited `src/bindings.ts` entry matching specta output style.
- **Tests**: `crates/libcalibre/tests/search_test.rs` with 7 tests covering title/author/series matching, wildcard escaping, and empty-query/no-match behavior. Series setup uses the `BookAdd` series write path introduced in CDL-10.

Fixes CDL-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)