### PR TITLE
feat: paged, sorted, filtered book queries

### DIFF
--- a/crates/libcalibre/src/lib.rs
+++ b/crates/libcalibre/src/lib.rs
@@ -19,7 +19,7 @@ pub use custom_columns::{CustomColumn, CustomColumnKind, CustomColumnSpec, Custo
 pub use error::CalibreError;
 pub use library::{
     Author as LibraryAuthor, AuthorAdd, AuthorUpdate, Book as LibraryBook, BookAdd, BookFileInfo,
-    BookIdentifier, BookUpdate, Library,
+    BookIdentifier, BookPage, BookQuery, BookSortOrder, BookUpdate, Library,
 };
 pub use types::{AuthorId, BookFileId, BookId};
 

--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -128,6 +128,51 @@ pub struct AuthorUpdate {
     pub link: Option<String>,
 }
 
+/// Sort order for [`Library::query_books`]. Orders by Calibre's precomputed
+/// sort columns (`books.sort` for titles, the primary linked author's
+/// `authors.sort` for authors), with `books.id` as a stable tiebreak.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum BookSortOrder {
+    #[default]
+    TitleAsc,
+    TitleDesc,
+    AuthorAsc,
+    AuthorDesc,
+}
+
+/// A paged, sorted, filtered book query. All filters compose (AND).
+#[derive(Clone, Debug, Default)]
+pub struct BookQuery {
+    /// Case-insensitive substring match across the book title, linked author
+    /// names, and linked series names, with LIKE wildcards escaped — the
+    /// same semantics as [`Library::search_books`], EXCEPT that `None` or
+    /// empty/whitespace text matches ALL books (where `search_books` returns
+    /// no books).
+    pub text: Option<String>,
+    /// Only books linked to this author.
+    pub author_id: Option<AuthorId>,
+    /// Only books linked to this series.
+    pub series_id: Option<i32>,
+    /// Exclude books marked read (filtered in SQL, so paging and totals stay
+    /// correct).
+    pub hide_read: bool,
+    pub sort: BookSortOrder,
+    /// Maximum number of books to return. `None` returns all matches.
+    pub limit: Option<i64>,
+    /// Number of matching books to skip before the page starts.
+    pub offset: i64,
+}
+
+/// One page of results from [`Library::query_books`].
+#[derive(Clone, Debug)]
+pub struct BookPage {
+    /// The fully hydrated books in this page, in sorted order.
+    pub items: Vec<Book>,
+    /// Total number of books matching the query's filters, ignoring
+    /// limit/offset.
+    pub total: i64,
+}
+
 impl Library {
     pub fn new(db_path: ValidDbPath) -> Result<Self, CalibreError> {
         let conn = establish_connection(&db_path.database_path)
@@ -675,19 +720,62 @@ impl Library {
     // Search
     // =========================================================================
 
+    /// Run a paged, sorted, filtered book query. Returns one page of
+    /// hydrated books plus the total match count (ignoring limit/offset).
+    pub fn query_books(&mut self, query: BookQuery) -> Result<BookPage, CalibreError> {
+        // The read state lives in the `read` bool custom column. When the
+        // column does not exist yet, no book has been marked read, so there
+        // is nothing to hide.
+        let hide_read_column = if query.hide_read {
+            custom_columns::find_by_label_and_kind(&mut self.conn, "read", &CustomColumnKind::Bool)?
+                .map(|column| column.id)
+        } else {
+            None
+        };
+
+        let filters = book_queries::BookPageFilters {
+            text: query
+                .text
+                .as_deref()
+                .map(str::trim)
+                .filter(|text| !text.is_empty()),
+            author_id: query.author_id,
+            series_id: query.series_id,
+            hide_read_column,
+        };
+
+        let total = book_queries::query_count(&mut self.conn, &filters)?;
+        let book_ids = book_queries::query_page(
+            &mut self.conn,
+            &filters,
+            query.sort,
+            query.limit,
+            query.offset,
+        )?;
+        let items = self.get_books_with_read_states(book_ids)?;
+
+        Ok(BookPage { items, total })
+    }
+
     pub fn search_books(&mut self, query: &str) -> Result<Vec<Book>, CalibreError> {
         let query = query.trim();
         if query.is_empty() {
             return Ok(vec![]);
         }
 
-        let book_ids = book_queries::search(&mut self.conn, query)?;
-        self.get_books_with_read_states(book_ids)
+        self.query_books(BookQuery {
+            text: Some(query.to_string()),
+            ..BookQuery::default()
+        })
+        .map(|page| page.items)
     }
 
     pub fn find_by_author(&mut self, author_id: AuthorId) -> Result<Vec<Book>, CalibreError> {
-        let book_ids = book_queries::find_by_author(&mut self.conn, author_id)?;
-        self.get_books_with_read_states(book_ids)
+        self.query_books(BookQuery {
+            author_id: Some(author_id),
+            ..BookQuery::default()
+        })
+        .map(|page| page.items)
     }
 
     fn get_books_with_read_states(

--- a/crates/libcalibre/src/queries/books.rs
+++ b/crates/libcalibre/src/queries/books.rs
@@ -4,9 +4,10 @@
 //! All functions use type-safe IDs and accept a mutable SQLite connection.
 
 use diesel::prelude::*;
-use diesel::sql_types::{Integer, Text};
+use diesel::sql_types::{BigInt, Integer, Text};
 use diesel::{sql_query, QueryDsl, QueryableByName, RunQueryDsl, SqliteConnection};
 
+use crate::library::BookSortOrder;
 use crate::types::AuthorId;
 use crate::{types::BookId, CalibreError};
 use crate::{BookRow, NewBook, UpdateBookData};
@@ -53,39 +54,161 @@ pub(crate) fn get_by_ids(
         .map_err(CalibreError::from)
 }
 
-pub(crate) fn search(
-    conn: &mut SqliteConnection,
-    query: &str,
-) -> Result<Vec<BookId>, CalibreError> {
-    #[derive(QueryableByName)]
-    struct MatchedBook {
-        #[diesel(sql_type = Integer)]
-        id: i32,
-    }
+// =============================================================================
+// Paged, sorted, filtered queries
+// =============================================================================
 
-    let escaped = query
+/// Filters shared by the paged id query and its COUNT twin. Both build their
+/// WHERE clause from [`filter_where_sql`] so the page and total cannot drift.
+pub(crate) struct BookPageFilters<'a> {
+    /// Case-insensitive substring match (LIKE wildcards escaped) across the
+    /// book title, linked author names, and linked series names.
+    pub text: Option<&'a str>,
+    pub author_id: Option<AuthorId>,
+    pub series_id: Option<i32>,
+    /// Id of the `read` bool custom column. When set, books marked read are
+    /// excluded.
+    pub hide_read_column: Option<i32>,
+}
+
+#[derive(QueryableByName)]
+struct IdRow {
+    #[diesel(sql_type = Integer)]
+    id: i32,
+}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    total: i64,
+}
+
+fn like_pattern(text: &str) -> String {
+    let escaped = text
         .replace('\\', "\\\\")
         .replace('%', "\\%")
         .replace('_', "\\_");
-    let pattern = format!("%{escaped}%");
+    format!("%{escaped}%")
+}
 
-    let matches: Vec<MatchedBook> = sql_query(
-        "SELECT DISTINCT books.id FROM books \
-         LEFT JOIN books_authors_link ON books_authors_link.book = books.id \
-         LEFT JOIN authors ON authors.id = books_authors_link.author \
-         LEFT JOIN books_series_link ON books_series_link.book = books.id \
-         LEFT JOIN series ON series.id = books_series_link.series \
-         WHERE books.title LIKE ? ESCAPE '\\' \
-            OR authors.name LIKE ? ESCAPE '\\' \
-            OR series.name LIKE ? ESCAPE '\\'",
-    )
-    .bind::<Text, _>(&pattern)
-    .bind::<Text, _>(&pattern)
-    .bind::<Text, _>(&pattern)
-    .load(conn)
-    .map_err(CalibreError::from)?;
+/// WHERE clause shared by [`query_page`] and [`query_count`]. The text filter
+/// uses three `?` placeholders (title, author name, series name); all other
+/// filters interpolate plain integers.
+fn filter_where_sql(filters: &BookPageFilters) -> String {
+    let mut clauses: Vec<String> = vec!["1=1".to_string()];
 
-    Ok(matches.into_iter().map(|m| BookId(m.id)).collect())
+    if filters.text.is_some() {
+        clauses.push(
+            "(books.title LIKE ? ESCAPE '\\' \
+              OR EXISTS (SELECT 1 FROM books_authors_link bal \
+                         JOIN authors a ON a.id = bal.author \
+                         WHERE bal.book = books.id AND a.name LIKE ? ESCAPE '\\') \
+              OR EXISTS (SELECT 1 FROM books_series_link bsl \
+                         JOIN series s ON s.id = bsl.series \
+                         WHERE bsl.book = books.id AND s.name LIKE ? ESCAPE '\\'))"
+                .to_string(),
+        );
+    }
+
+    if let Some(author_id) = filters.author_id {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM books_authors_link bal2 \
+             WHERE bal2.book = books.id AND bal2.author = {})",
+            author_id.as_i32()
+        ));
+    }
+
+    if let Some(series_id) = filters.series_id {
+        clauses.push(format!(
+            "EXISTS (SELECT 1 FROM books_series_link bsl2 \
+             WHERE bsl2.book = books.id AND bsl2.series = {series_id})"
+        ));
+    }
+
+    if let Some(n) = filters.hide_read_column {
+        clauses.push(format!(
+            "NOT EXISTS (SELECT 1 FROM custom_column_{n} cc \
+             WHERE cc.book = books.id AND cc.value != 0)"
+        ));
+    }
+
+    clauses.join(" AND ")
+}
+
+/// ORDER BY clause for [`query_page`]. Uses Calibre's precomputed sort
+/// columns (`books.sort` for titles, the primary linked author's
+/// `authors.sort` for authors), with `books.id` as a stable tiebreak.
+fn order_by_sql(sort: BookSortOrder) -> String {
+    const AUTHOR_SORT: &str = "(SELECT a.sort FROM books_authors_link bal \
+         JOIN authors a ON a.id = bal.author \
+         WHERE bal.book = books.id ORDER BY bal.id LIMIT 1)";
+
+    match sort {
+        BookSortOrder::TitleAsc => "books.sort ASC, books.id ASC".to_string(),
+        BookSortOrder::TitleDesc => "books.sort DESC, books.id DESC".to_string(),
+        BookSortOrder::AuthorAsc => format!("{AUTHOR_SORT} ASC, books.id ASC"),
+        BookSortOrder::AuthorDesc => format!("{AUTHOR_SORT} DESC, books.id DESC"),
+    }
+}
+
+/// One page of matching book ids, in sorted order. `limit: None` returns all
+/// matches (after `offset`).
+pub(crate) fn query_page(
+    conn: &mut SqliteConnection,
+    filters: &BookPageFilters,
+    sort: BookSortOrder,
+    limit: Option<i64>,
+    offset: i64,
+) -> Result<Vec<BookId>, CalibreError> {
+    let where_sql = filter_where_sql(filters);
+    let order_sql = order_by_sql(sort);
+    // SQLite treats a negative LIMIT as "no limit"; OFFSET still applies.
+    let limit = limit.map(|l| l.max(0)).unwrap_or(-1);
+    let offset = offset.max(0);
+
+    let sql = format!(
+        "SELECT books.id FROM books WHERE {where_sql} \
+         ORDER BY {order_sql} LIMIT {limit} OFFSET {offset}"
+    );
+
+    let rows: Vec<IdRow> = match filters.text {
+        Some(text) => {
+            let pattern = like_pattern(text);
+            sql_query(sql)
+                .bind::<Text, _>(&pattern)
+                .bind::<Text, _>(&pattern)
+                .bind::<Text, _>(&pattern)
+                .load(conn)
+                .map_err(CalibreError::from)?
+        }
+        None => sql_query(sql).load(conn).map_err(CalibreError::from)?,
+    };
+
+    Ok(rows.into_iter().map(|row| BookId(row.id)).collect())
+}
+
+/// COUNT over the same WHERE as [`query_page`], ignoring limit/offset.
+pub(crate) fn query_count(
+    conn: &mut SqliteConnection,
+    filters: &BookPageFilters,
+) -> Result<i64, CalibreError> {
+    let where_sql = filter_where_sql(filters);
+    let sql = format!("SELECT COUNT(*) AS total FROM books WHERE {where_sql}");
+
+    let rows: Vec<CountRow> = match filters.text {
+        Some(text) => {
+            let pattern = like_pattern(text);
+            sql_query(sql)
+                .bind::<Text, _>(&pattern)
+                .bind::<Text, _>(&pattern)
+                .bind::<Text, _>(&pattern)
+                .load(conn)
+                .map_err(CalibreError::from)?
+        }
+        None => sql_query(sql).load(conn).map_err(CalibreError::from)?,
+    };
+
+    Ok(rows.first().map(|row| row.total).unwrap_or(0))
 }
 
 pub(crate) fn create(conn: &mut SqliteConnection, book: NewBook) -> Result<BookRow, CalibreError> {
@@ -138,18 +261,4 @@ pub(crate) fn find_authors(
         .map_err(CalibreError::from)?;
 
     Ok(author_ids)
-}
-
-pub(crate) fn find_by_author(
-    conn: &mut SqliteConnection,
-    author_id: AuthorId,
-) -> Result<Vec<BookId>, CalibreError> {
-    use crate::schema::books_authors_link::dsl::*;
-
-    books_authors_link
-        .filter(author.eq(author_id.as_i32()))
-        .select(book)
-        .load(conn)
-        .map(|ids: Vec<i32>| ids.into_iter().map(BookId).collect())
-        .map_err(CalibreError::from)
 }

--- a/crates/libcalibre/tests/query_test.rs
+++ b/crates/libcalibre/tests/query_test.rs
@@ -1,0 +1,532 @@
+// Tests for Library::query_books — paged, sorted, filtered book queries.
+// This binary uses only a subset of the shared test helpers.
+#[allow(dead_code, unused_imports)]
+mod common;
+
+use common::setup_with_library;
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{Integer, Text};
+use libcalibre::{BookAdd, BookId, BookPage, BookQuery, BookSortOrder, Library};
+use std::collections::HashMap;
+
+fn book(title: &str, author_names: &[&str]) -> BookAdd {
+    BookAdd {
+        title: title.to_string(),
+        author_names: author_names.iter().map(|n| (*n).to_string()).collect(),
+        tags: None,
+        series: None,
+        series_index: None,
+        publisher: None,
+        publication_date: None,
+        rating: None,
+        comments: None,
+        identifiers: HashMap::new(),
+        file_paths: vec![],
+    }
+}
+
+fn query(lib: &mut Library, q: BookQuery) -> BookPage {
+    lib.query_books(q).unwrap()
+}
+
+fn titles(page: &BookPage) -> Vec<String> {
+    page.items.iter().map(|b| b.title.clone()).collect()
+}
+
+fn series_id_by_name(lib: &mut Library, name: &str) -> i32 {
+    #[derive(QueryableByName)]
+    struct IdRow {
+        #[diesel(sql_type = Integer)]
+        id: i32,
+    }
+
+    let mut conn = libcalibre::persistence::establish_connection(lib.database_path())
+        .expect("failed to open test db");
+    let row: IdRow = sql_query("SELECT id FROM series WHERE name = ?")
+        .bind::<Text, _>(name)
+        .get_result(&mut conn)
+        .expect("series not found");
+    row.id
+}
+
+// =============================================================================
+// Paging
+// =============================================================================
+
+#[test]
+fn test_pages_tile_the_full_set() {
+    let (_temp, mut lib) = setup_with_library();
+
+    for n in 1..=7 {
+        lib.add_book(book(&format!("Book {n:02}"), &["Some Author"]))
+            .unwrap();
+    }
+
+    let unpaged = query(&mut lib, BookQuery::default());
+    assert_eq!(unpaged.items.len(), 7);
+    assert_eq!(unpaged.total, 7);
+
+    let mut tiled: Vec<BookId> = Vec::new();
+    for page_index in 0..3 {
+        let page = query(
+            &mut lib,
+            BookQuery {
+                limit: Some(3),
+                offset: page_index * 3,
+                ..BookQuery::default()
+            },
+        );
+        // Total stays constant across pages and ignores limit/offset.
+        assert_eq!(page.total, 7);
+        tiled.extend(page.items.iter().map(|b| b.id));
+    }
+
+    let unpaged_ids: Vec<BookId> = unpaged.items.iter().map(|b| b.id).collect();
+    assert_eq!(tiled, unpaged_ids);
+}
+
+#[test]
+fn test_partial_last_page() {
+    let (_temp, mut lib) = setup_with_library();
+
+    for n in 1..=5 {
+        lib.add_book(book(&format!("Book {n:02}"), &[])).unwrap();
+    }
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            limit: Some(3),
+            offset: 3,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(page.items.len(), 2);
+    assert_eq!(page.total, 5);
+}
+
+#[test]
+fn test_offset_past_end_is_empty() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book("Only Book", &[])).unwrap();
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            limit: Some(10),
+            offset: 5,
+            ..BookQuery::default()
+        },
+    );
+    assert!(page.items.is_empty());
+    assert_eq!(page.total, 1);
+}
+
+// =============================================================================
+// Sorting
+// =============================================================================
+
+fn sorting_fixture(lib: &mut Library) {
+    // Title sort uses books.sort, so "The Zebra Guide" sorts as
+    // "Zebra Guide, The". Author sort uses authors.sort (APA style).
+    lib.add_book(book("The Zebra Guide", &["Jane Austen"]))
+        .unwrap();
+    lib.add_book(book("Apple Picking", &["Herman Melville"]))
+        .unwrap();
+    lib.add_book(book("Mangoes", &["Charles Dickens"])).unwrap();
+}
+
+#[test]
+fn test_sort_title_asc() {
+    let (_temp, mut lib) = setup_with_library();
+    sorting_fixture(&mut lib);
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            sort: BookSortOrder::TitleAsc,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(
+        titles(&page),
+        ["Apple Picking", "Mangoes", "The Zebra Guide"]
+    );
+}
+
+#[test]
+fn test_sort_title_desc() {
+    let (_temp, mut lib) = setup_with_library();
+    sorting_fixture(&mut lib);
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            sort: BookSortOrder::TitleDesc,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(
+        titles(&page),
+        ["The Zebra Guide", "Mangoes", "Apple Picking"]
+    );
+}
+
+#[test]
+fn test_sort_author_asc() {
+    let (_temp, mut lib) = setup_with_library();
+    sorting_fixture(&mut lib);
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            sort: BookSortOrder::AuthorAsc,
+            ..BookQuery::default()
+        },
+    );
+    // Austen < Dickens < Melville
+    assert_eq!(
+        titles(&page),
+        ["The Zebra Guide", "Mangoes", "Apple Picking"]
+    );
+}
+
+#[test]
+fn test_sort_author_desc() {
+    let (_temp, mut lib) = setup_with_library();
+    sorting_fixture(&mut lib);
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            sort: BookSortOrder::AuthorDesc,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(
+        titles(&page),
+        ["Apple Picking", "Mangoes", "The Zebra Guide"]
+    );
+}
+
+#[test]
+fn test_sort_ties_break_by_book_id() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let first = lib.add_book(book("Same Title", &[])).unwrap();
+    let second = lib.add_book(book("Same Title", &[])).unwrap();
+
+    let asc = query(
+        &mut lib,
+        BookQuery {
+            sort: BookSortOrder::TitleAsc,
+            ..BookQuery::default()
+        },
+    );
+    let asc_ids: Vec<BookId> = asc.items.iter().map(|b| b.id).collect();
+    assert_eq!(asc_ids, [first.id, second.id]);
+
+    let desc = query(
+        &mut lib,
+        BookQuery {
+            sort: BookSortOrder::TitleDesc,
+            ..BookQuery::default()
+        },
+    );
+    let desc_ids: Vec<BookId> = desc.items.iter().map(|b| b.id).collect();
+    assert_eq!(desc_ids, [second.id, first.id]);
+}
+
+// =============================================================================
+// Text filter
+// =============================================================================
+
+#[test]
+fn test_empty_text_matches_all_books() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book("Book One", &[])).unwrap();
+    lib.add_book(book("Book Two", &[])).unwrap();
+
+    for text in [None, Some(String::new()), Some("   \t\n".to_string())] {
+        let page = query(
+            &mut lib,
+            BookQuery {
+                text,
+                ..BookQuery::default()
+            },
+        );
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.total, 2);
+    }
+}
+
+#[test]
+fn test_text_matches_title_author_and_series() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book("The Rust Programming Language", &["Steve Klabnik"]))
+        .unwrap();
+    lib.add_book(book("Pride and Prejudice", &["Jane Austen"]))
+        .unwrap();
+    lib.add_book(BookAdd {
+        series: Some("The Lord of the Rings".to_string()),
+        series_index: Some(1.0),
+        ..book("The Fellowship of the Ring", &["J. R. R. Tolkien"])
+    })
+    .unwrap();
+
+    let by_title = query(
+        &mut lib,
+        BookQuery {
+            text: Some("RUST".to_string()),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&by_title), ["The Rust Programming Language"]);
+    assert_eq!(by_title.total, 1);
+
+    let by_author = query(
+        &mut lib,
+        BookQuery {
+            text: Some("austen".to_string()),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&by_author), ["Pride and Prejudice"]);
+
+    let by_series = query(
+        &mut lib,
+        BookQuery {
+            text: Some("lord of the rings".to_string()),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&by_series), ["The Fellowship of the Ring"]);
+}
+
+#[test]
+fn test_text_escapes_like_wildcards() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book("100% Done", &[])).unwrap();
+    lib.add_book(book("Another Book", &[])).unwrap();
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            text: Some("100%".to_string()),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&page), ["100% Done"]);
+    assert_eq!(page.total, 1);
+
+    let no_match = query(
+        &mut lib,
+        BookQuery {
+            text: Some("z%y".to_string()),
+            ..BookQuery::default()
+        },
+    );
+    assert!(no_match.items.is_empty());
+    assert_eq!(no_match.total, 0);
+}
+
+// =============================================================================
+// Author, series, and read-state filters
+// =============================================================================
+
+#[test]
+fn test_author_id_filter() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let emma = lib.add_book(book("Emma", &["Jane Austen"])).unwrap();
+    lib.add_book(book("Persuasion", &["Jane Austen"])).unwrap();
+    lib.add_book(book("Moby Dick", &["Herman Melville"]))
+        .unwrap();
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            author_id: Some(emma.authors[0].id),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&page), ["Emma", "Persuasion"]);
+    assert_eq!(page.total, 2);
+}
+
+#[test]
+fn test_author_id_and_text_compose() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let emma = lib.add_book(book("Emma", &["Jane Austen"])).unwrap();
+    lib.add_book(book("Persuasion", &["Jane Austen"])).unwrap();
+    lib.add_book(book("Emma: A Biography", &["Herman Melville"]))
+        .unwrap();
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            text: Some("emma".to_string()),
+            author_id: Some(emma.authors[0].id),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&page), ["Emma"]);
+    assert_eq!(page.total, 1);
+}
+
+#[test]
+fn test_series_id_filter() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(BookAdd {
+        series: Some("Earthsea".to_string()),
+        series_index: Some(1.0),
+        ..book("A Wizard of Earthsea", &["Ursula K. Le Guin"])
+    })
+    .unwrap();
+    lib.add_book(BookAdd {
+        series: Some("Earthsea".to_string()),
+        series_index: Some(2.0),
+        ..book("The Tombs of Atuan", &["Ursula K. Le Guin"])
+    })
+    .unwrap();
+    lib.add_book(book("Unrelated Book", &["Ursula K. Le Guin"]))
+        .unwrap();
+
+    let earthsea_id = series_id_by_name(&mut lib, "Earthsea");
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            series_id: Some(earthsea_id),
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(
+        titles(&page),
+        ["The Tombs of Atuan", "A Wizard of Earthsea"]
+    );
+    assert_eq!(page.total, 2);
+}
+
+#[test]
+fn test_hide_read_filters_in_sql() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let read_book = lib.add_book(book("Already Read", &[])).unwrap();
+    let unread_then_read = lib.add_book(book("Toggled Back", &[])).unwrap();
+    lib.add_book(book("Never Touched", &[])).unwrap();
+
+    lib.set_book_read_state(read_book.id, true).unwrap();
+    // A book toggled read then unread (stored value 0) stays visible.
+    lib.set_book_read_state(unread_then_read.id, true).unwrap();
+    lib.set_book_read_state(unread_then_read.id, false).unwrap();
+
+    let page = query(
+        &mut lib,
+        BookQuery {
+            hide_read: true,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&page), ["Never Touched", "Toggled Back"]);
+    // Totals come from the same SQL filter, not post-hydration filtering.
+    assert_eq!(page.total, 2);
+
+    let all = query(&mut lib, BookQuery::default());
+    assert_eq!(all.total, 3);
+}
+
+#[test]
+fn test_hide_read_with_no_read_column_matches_all() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book("Fresh Library Book", &[])).unwrap();
+
+    // No book has ever been marked read, so the custom column may not exist.
+    let page = query(
+        &mut lib,
+        BookQuery {
+            hide_read: true,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.total, 1);
+}
+
+#[test]
+fn test_hide_read_respects_paging_and_totals() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let mut unread_titles = Vec::new();
+    for n in 1..=6 {
+        let added = lib.add_book(book(&format!("Book {n:02}"), &[])).unwrap();
+        if n % 2 == 0 {
+            lib.set_book_read_state(added.id, true).unwrap();
+        } else {
+            unread_titles.push(format!("Book {n:02}"));
+        }
+    }
+
+    let first_page = query(
+        &mut lib,
+        BookQuery {
+            hide_read: true,
+            limit: Some(2),
+            offset: 0,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&first_page), unread_titles[0..2]);
+    assert_eq!(first_page.total, 3);
+
+    let last_page = query(
+        &mut lib,
+        BookQuery {
+            hide_read: true,
+            limit: Some(2),
+            offset: 2,
+            ..BookQuery::default()
+        },
+    );
+    assert_eq!(titles(&last_page), unread_titles[2..3]);
+    assert_eq!(last_page.total, 3);
+}
+
+// =============================================================================
+// Hydration
+// =============================================================================
+
+#[test]
+fn test_page_items_are_hydrated() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let added = lib
+        .add_book(BookAdd {
+            series: Some("Earthsea".to_string()),
+            series_index: Some(1.0),
+            tags: Some(vec!["fantasy".to_string()]),
+            ..book("A Wizard of Earthsea", &["Ursula K. Le Guin"])
+        })
+        .unwrap();
+    lib.set_book_read_state(added.id, true).unwrap();
+
+    let page = query(&mut lib, BookQuery::default());
+    assert_eq!(page.items.len(), 1);
+
+    let item = &page.items[0];
+    assert_eq!(item.title, "A Wizard of Earthsea");
+    assert_eq!(item.authors.len(), 1);
+    assert_eq!(item.authors[0].name, "Ursula K. Le Guin");
+    assert_eq!(item.series.as_deref(), Some("Earthsea"));
+    assert_eq!(item.series_index, Some(1.0));
+    assert_eq!(item.tags, ["fantasy"]);
+    assert!(item.is_read);
+}

--- a/src-tauri/src/libs/calibre/book.rs
+++ b/src-tauri/src/libs/calibre/book.rs
@@ -63,3 +63,19 @@ pub fn search(
         .map(|book| to_library_book(&library_root, book))
         .collect())
 }
+
+pub fn query_page(
+    library_root: String,
+    lib: &mut Library,
+    query: libcalibre::BookQuery,
+) -> Result<(Vec<LibraryBook>, i64), libcalibre::CalibreError> {
+    let page = lib.query_books(query)?;
+
+    Ok((
+        page.items
+            .iter()
+            .map(|book| to_library_book(&library_root, book))
+            .collect(),
+        page.total,
+    ))
+}

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use libcalibre::mime_type::MIMETYPE;
+use serde::{Deserialize, Serialize};
 
 use crate::book::{ImportableBookMetadata, LibraryAuthor};
 use crate::calibre::book;
@@ -35,6 +36,84 @@ pub fn clb_query_search_books(
 
     let books = state.with_library(|lib| book::search(library_root, lib, &query))?;
     books.map_err(|e| e.to_string())
+}
+
+#[derive(Serialize, Deserialize, specta::Type, Clone, Copy, Debug)]
+pub enum BookSortOrder {
+    TitleAsc,
+    TitleDesc,
+    AuthorAsc,
+    AuthorDesc,
+}
+
+impl From<BookSortOrder> for libcalibre::BookSortOrder {
+    fn from(sort: BookSortOrder) -> Self {
+        match sort {
+            BookSortOrder::TitleAsc => libcalibre::BookSortOrder::TitleAsc,
+            BookSortOrder::TitleDesc => libcalibre::BookSortOrder::TitleDesc,
+            BookSortOrder::AuthorAsc => libcalibre::BookSortOrder::AuthorAsc,
+            BookSortOrder::AuthorDesc => libcalibre::BookSortOrder::AuthorDesc,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, specta::Type, Clone, Debug)]
+pub struct LibraryBookQuery {
+    /// Substring match across title, author names, and series names.
+    /// `None` or empty text matches all books.
+    pub text: Option<String>,
+    pub author_id: Option<String>,
+    pub series_id: Option<i32>,
+    pub hide_read: bool,
+    pub sort: BookSortOrder,
+    /// Page size. `None` returns all matches.
+    pub limit: Option<u32>,
+    pub offset: u32,
+}
+
+#[derive(Serialize, Deserialize, specta::Type, Clone)]
+pub struct LibraryBookPage {
+    pub items: Vec<LibraryBook>,
+    /// Total number of books matching the filters, ignoring limit/offset.
+    pub total: u32,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_books(
+    state: tauri::State<CitadelState>,
+    query: LibraryBookQuery,
+) -> Result<LibraryBookPage, String> {
+    let library_root = state
+        .get_library_path()
+        .ok_or("No library loaded".to_string())?;
+
+    let author_id = query
+        .author_id
+        .as_deref()
+        .map(|raw| {
+            raw.parse::<libcalibre::AuthorId>()
+                .map_err(|e| format!("Invalid author id '{raw}': {e}"))
+        })
+        .transpose()?;
+
+    let book_query = libcalibre::BookQuery {
+        text: query.text,
+        author_id,
+        series_id: query.series_id,
+        hide_read: query.hide_read,
+        sort: query.sort.into(),
+        limit: query.limit.map(i64::from),
+        offset: i64::from(query.offset),
+    };
+
+    let page = state.with_library(|lib| book::query_page(library_root, lib, book_query))?;
+    let (items, total) = page.map_err(|e| e.to_string())?;
+
+    Ok(LibraryBookPage {
+        items,
+        total: u32::try_from(total).unwrap_or(u32::MAX),
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -27,6 +27,7 @@ fn run_tauri_backend() -> std::io::Result<()> {
         // Book query commands
         calibre::query::clb_query_list_all_books,
         calibre::query::clb_query_search_books,
+        calibre::query::clb_query_books,
         calibre::query::clb_query_is_file_importable,
         calibre::query::clb_query_importable_file_metadata,
         calibre::query::clb_query_list_all_filetypes,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -40,6 +40,14 @@ async clbQuerySearchBooks(query: string) : Promise<Result<LibraryBook[], string>
     else return { status: "error", error: e  as any };
 }
 },
+async clbQueryBooks(query: LibraryBookQuery) : Promise<Result<LibraryBookPage, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_books", { query }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbQueryIsFileImportable(pathToFile: string) : Promise<ImportableFile | null> {
     return await TAURI_INVOKE("clb_query_is_file_importable", { pathToFile });
 },
@@ -214,6 +222,7 @@ export type AuthorUpdate = { full_name: string | null; sortable_name: string | n
  */
 export type BookCustomValue = { column_id: number; value: CustomValueDto }
 export type BookFile = { Local: LocalFile } | { Remote: RemoteFile }
+export type BookSortOrder = "TitleAsc" | "TitleDesc" | "AuthorAsc" | "AuthorDesc"
 export type BookUpdate = { author_id_list: string[] | null; tag_list: string[] | null; title: string | null; timestamp: string | null; publication_date: string | null; is_read: boolean | null; description: string | null; 
 /**
  * An empty (or whitespace) name unlinks the book from its series;
@@ -289,6 +298,21 @@ export type ImportableBookType = "Epub" | "Pdf" | "Mobi" | "Text"
 export type ImportableFile = { path: string }
 export type LibraryAuthor = { id: string; name: string; sortable_name: string }
 export type LibraryBook = { id: string; uuid: string | null; title: string; author_list: LibraryAuthor[]; tag_list: string[]; sortable_title: string | null; file_list: BookFile[]; cover_image: LocalOrRemoteUrl | null; identifier_list: Identifier[]; description: string | null; is_read: boolean; series: string | null; series_index: number | null }
+export type LibraryBookPage = { items: LibraryBook[];
+/**
+ * Total number of books matching the filters, ignoring limit/offset.
+ */
+total: number }
+export type LibraryBookQuery = { 
+/**
+ * Substring match across title, author names, and series names.
+ * `None` or empty text matches all books.
+ */
+text: string | null; author_id: string | null; series_id: number | null; hide_read: boolean; sort: BookSortOrder; 
+/**
+ * Page size. `None` returns all matches.
+ */
+limit: number | null; offset: number }
 export type LocalFile = { 
 /**
  * The absolute path to the file, including extension.


### PR DESCRIPTION
## What

Generalizes the CDL-3 search (#112) into a paged, sorted, filtered book query — the backend for library pagination.

### libcalibre

New public entry point:

```rust
Library::query_books(BookQuery) -> Result<BookPage, CalibreError>

pub struct BookQuery {
    pub text: Option<String>,      // LIKE across title/author/series, wildcard-escaped;
                                   // None/empty matches ALL books (unlike search_books)
    pub author_id: Option<AuthorId>,
    pub series_id: Option<i32>,
    pub hide_read: bool,           // filtered in SQL via the `read` bool custom column
    pub sort: BookSortOrder,       // TitleAsc/TitleDesc/AuthorAsc/AuthorDesc
    pub limit: Option<i64>,        // None = all matches
    pub offset: i64,
}

pub struct BookPage {
    pub items: Vec<Book>,  // hydrated, in sorted order
    pub total: i64,        // COUNT over the same WHERE, ignoring limit/offset
}
```

- One SQL query produces the page of matching ids in sorted order; only those are hydrated via the order-preserving `get_many` path.
- The COUNT twin shares the WHERE construction (`filter_where_sql`) with the page query, so page and total cannot drift.
- Sorting uses Calibre's precomputed sort columns (`books.sort` for title, the primary linked author's `authors.sort` for author) with `books.id` as a stable tiebreak.
- `hide_read` filters in SQL against the `read` bool custom column (post-hydration filtering would break totals and page sizes). A library where the column doesn't exist yet hides nothing.
- `search_books` and `find_by_author` keep their public APIs, reimplemented atop `query_books`.

### Tauri

- New command `clb_query_books(query: LibraryBookQuery) -> Result<LibraryBookPage, String>` (`{ items: Vec<LibraryBook>, total: u32 }`), reusing the existing `to_library_book` mapping so covers etc. stay consistent.
- Registered in `collect_commands!`; `src/bindings.ts` hand-edited in specta output style (`clbQueryBooks`, `BookSortOrder`, `LibraryBookQuery`, `LibraryBookPage`).
- `clb_query_list_all_books` and `clb_query_search_books` are untouched.

## Test coverage

`crates/libcalibre/tests/query_test.rs` (18 tests):

- Paging: limit/offset windows tile the full set, partial last page, offset past end is empty, total constant across pages and equal to items when unpaged
- All four sort orders, including the `books.id` tiebreak in both directions
- Text: empty/None matches all, matches title/author/series, LIKE wildcard escaping
- Filters: `author_id`, `author_id` + text composition, `series_id` (fixtures via BookAdd's series write path), `hide_read` (incl. read-then-unread books staying visible, missing column, and paging/totals under the filter)
- Hydration of page items (authors, series, tags, read state)

Existing `search_test.rs` still passes against the reimplemented `search_books`/`find_by_author`.

Gates: `cargo fmt --all`, `cargo clippy --workspace`, `cargo test --workspace`, `bunx tsc --noEmit`, `bunx biome lint src/`, `bunx vitest run` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)