### PR TITLE
feat: backend-paged library browsing

### DIFF
--- a/crates/libcalibre/src/lib.rs
+++ b/crates/libcalibre/src/lib.rs
@@ -19,7 +19,7 @@ pub use custom_columns::{CustomColumn, CustomColumnKind, CustomColumnSpec, Custo
 pub use error::CalibreError;
 pub use library::{
     Author as LibraryAuthor, AuthorAdd, AuthorUpdate, Book as LibraryBook, BookAdd, BookFileInfo,
-    BookIdentifier, BookPage, BookQuery, BookSortOrder, BookUpdate, Library,
+    BookIdentifier, BookPage, BookQuery, BookSortOrder, BookUpdate, Library, SeriesSummary,
 };
 pub use types::{AuthorId, BookFileId, BookId};
 

--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -173,6 +173,16 @@ pub struct BookPage {
     pub total: i64,
 }
 
+/// One series in the library, with its linked-book count. Returned by
+/// [`Library::list_series`]; series ids are what [`BookQuery::series_id`]
+/// filters on.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SeriesSummary {
+    pub id: i32,
+    pub name: String,
+    pub book_count: i64,
+}
+
 impl Library {
     pub fn new(db_path: ValidDbPath) -> Result<Self, CalibreError> {
         let conn = establish_connection(&db_path.database_path)
@@ -755,6 +765,12 @@ impl Library {
         let items = self.get_books_with_read_states(book_ids)?;
 
         Ok(BookPage { items, total })
+    }
+
+    /// List every series in the library with its linked-book count, sorted
+    /// by name. The returned ids feed [`BookQuery::series_id`].
+    pub fn list_series(&mut self) -> Result<Vec<SeriesSummary>, CalibreError> {
+        crate::queries::series::list_with_book_counts(&mut self.conn)
     }
 
     pub fn search_books(&mut self, query: &str) -> Result<Vec<Book>, CalibreError> {

--- a/crates/libcalibre/src/queries/series.rs
+++ b/crates/libcalibre/src/queries/series.rs
@@ -2,12 +2,46 @@ use std::collections::HashMap;
 
 use diesel::prelude::*;
 use diesel::sql_query;
-use diesel::sql_types::{Integer, Text};
+use diesel::sql_types::{BigInt, Integer, Text};
 use diesel::{QueryDsl, RunQueryDsl, SqliteConnection};
 
 use crate::entities::series::{NewSeries, Series};
+use crate::library::SeriesSummary;
 use crate::types::BookId;
 use crate::CalibreError;
+
+pub(crate) fn list_with_book_counts(
+    conn: &mut SqliteConnection,
+) -> Result<Vec<SeriesSummary>, CalibreError> {
+    #[derive(QueryableByName)]
+    struct SeriesCountRow {
+        #[diesel(sql_type = Integer)]
+        id: i32,
+        #[diesel(sql_type = Text)]
+        name: String,
+        #[diesel(sql_type = BigInt)]
+        book_count: i64,
+    }
+
+    let rows: Vec<SeriesCountRow> = sql_query(
+        "SELECT s.id AS id, s.name AS name, COUNT(bsl.book) AS book_count
+         FROM series s
+         LEFT JOIN books_series_link bsl ON bsl.series = s.id
+         GROUP BY s.id, s.name
+         ORDER BY s.name COLLATE NOCASE, s.id",
+    )
+    .load(conn)
+    .map_err(CalibreError::from)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| SeriesSummary {
+            id: row.id,
+            name: row.name,
+            book_count: row.book_count,
+        })
+        .collect())
+}
 
 pub(crate) fn find_by_name_case_insensitive(
     conn: &mut SqliteConnection,

--- a/crates/libcalibre/tests/query_test.rs
+++ b/crates/libcalibre/tests/query_test.rs
@@ -530,3 +530,39 @@ fn test_page_items_are_hydrated() {
     assert_eq!(item.tags, ["fantasy"]);
     assert!(item.is_read);
 }
+
+// =============================================================================
+// Series listing
+// =============================================================================
+
+#[test]
+fn test_list_series_returns_counts_sorted_by_name() {
+    let (_temp, mut lib) = setup_with_library();
+
+    for n in 1u8..=2 {
+        lib.add_book(BookAdd {
+            series: Some("Earthsea".to_string()),
+            series_index: Some(f32::from(n)),
+            ..book(&format!("Earthsea {n}"), &["Ursula K. Le Guin"])
+        })
+        .unwrap();
+    }
+    lib.add_book(BookAdd {
+        series: Some("Culture".to_string()),
+        series_index: Some(1.0),
+        ..book("Consider Phlebas", &["Iain M. Banks"])
+    })
+    .unwrap();
+    lib.add_book(book("Standalone", &["Nobody"])).unwrap();
+
+    let series = lib.list_series().unwrap();
+    let names: Vec<&str> = series.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, ["Culture", "Earthsea"]);
+
+    let counts: Vec<i64> = series.iter().map(|s| s.book_count).collect();
+    assert_eq!(counts, [1, 2]);
+
+    // The listed ids are the ones BookQuery::series_id filters on.
+    let earthsea = series.iter().find(|s| s.name == "Earthsea").unwrap();
+    assert_eq!(earthsea.id, series_id_by_name(&mut lib, "Earthsea"));
+}

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -116,6 +116,34 @@ pub fn clb_query_books(
     })
 }
 
+/// One series in the library. `id` is what [`LibraryBookQuery::series_id`]
+/// filters on; the frontend otherwise only ever sees series names.
+#[derive(Serialize, Deserialize, specta::Type, Clone)]
+pub struct LibrarySeries {
+    pub id: i32,
+    pub name: String,
+    pub book_count: u32,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_list_series(
+    state: tauri::State<CitadelState>,
+) -> Result<Vec<LibrarySeries>, String> {
+    let summaries = state
+        .with_library(|lib| lib.list_series())?
+        .map_err(|e| e.to_string())?;
+
+    Ok(summaries
+        .into_iter()
+        .map(|series| LibrarySeries {
+            id: series.id,
+            name: series.name,
+            book_count: u32::try_from(series.book_count).unwrap_or(u32::MAX),
+        })
+        .collect())
+}
+
 #[tauri::command]
 #[specta::specta]
 pub fn clb_query_list_all_authors(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -31,6 +31,8 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::query::clb_query_is_file_importable,
         calibre::query::clb_query_importable_file_metadata,
         calibre::query::clb_query_list_all_filetypes,
+        // Series query commands
+        calibre::query::clb_query_list_series,
         // Book manipulation commands
         calibre::command::clb_cmd_create_book,
         calibre::command::clb_cmd_update_book,

--- a/src/BookView.ts
+++ b/src/BookView.ts
@@ -2,7 +2,12 @@ import type { LibraryBook } from "./bindings";
 
 export interface BookView {
 	loading: boolean;
-	bookList: LibraryBook[];
+	/**
+	 * Indexed array of the filtered library: length is the total match
+	 * count, `undefined` entries are books whose page has not been fetched
+	 * yet (they render as placeholders).
+	 */
+	bookList: (LibraryBook | undefined)[];
 	onBookOpen: (bookId: LibraryBook["id"]) => void;
 	selectedBookId?: LibraryBook["id"] | null;
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -57,6 +57,14 @@ async clbQueryImportableFileMetadata(file: ImportableFile) : Promise<ImportableB
 async clbQueryListAllFiletypes() : Promise<([string, string])[]> {
     return await TAURI_INVOKE("clb_query_list_all_filetypes");
 },
+async clbQueryListSeries() : Promise<Result<LibrarySeries[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_list_series") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbCmdCreateBook(md: ImportableBookMetadata) : Promise<Result<string, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clb_cmd_create_book", { md }) };
@@ -313,6 +321,11 @@ text: string | null; author_id: string | null; series_id: number | null; hide_re
  * Page size. `None` returns all matches.
  */
 limit: number | null; offset: number }
+/**
+ * One series in the library. `id` is what [`LibraryBookQuery::series_id`]
+ * filters on; the frontend otherwise only ever sees series names.
+ */
+export type LibrarySeries = { id: number; name: string; book_count: number }
 export type LocalFile = { 
 /**
  * The absolute path to the file, including extension.

--- a/src/components/atoms/BookCard.module.css
+++ b/src/components/atoms/BookCard.module.css
@@ -33,3 +33,17 @@
 	outline-offset: 2px;
 	box-shadow: 0 0 0 7px var(--ctd-focus-ring);
 }
+
+/* Cover-shaped stand-in for a book whose page has not been fetched yet
+ * (BookGrid placeholder cells). Sized like a typical cover (2:3, capped at
+ * the shelf height) so rows hold steady while real books stream in. */
+.coverPlaceholder {
+	display: block;
+	width: 100%;
+	max-width: 150px;
+	aspect-ratio: 2 / 3;
+	max-height: 230px;
+	border-radius: 4px;
+	background: var(--ctd-surface-muted);
+	border: 1px solid var(--ctd-border);
+}

--- a/src/components/molecules/BookGrid.tsx
+++ b/src/components/molecules/BookGrid.tsx
@@ -20,6 +20,7 @@ import {
 	rowSlice,
 } from "@/lib/grid-virtual";
 import { BookCard } from "../atoms/BookCard";
+import cardClasses from "../atoms/BookCard.module.css";
 
 /**
  * Shelf-grid layout constants. The per-row tracks mirror the old
@@ -37,6 +38,9 @@ const OVERSCAN_ROWS = 4;
 /** Scrolls the shelf row containing the given flat book index into view. */
 export type ScrollToBookIndex = (index: number) => void;
 
+/** The inclusive flat-index range of books near the viewport. */
+export type VisibleRangeChange = (startIndex: number, endIndex: number) => void;
+
 interface BookGridProps extends BookView {
 	/** The page-owned scroll region the virtualizer windows against. */
 	scrollElementRef: RefObject<HTMLElement>;
@@ -45,6 +49,11 @@ interface BookGridProps extends BookView {
 	 * reach rows that are not currently mounted (use-library-keymap).
 	 */
 	scrollToBookIndexRef?: MutableRefObject<ScrollToBookIndex | null>;
+	/**
+	 * Fires when the rendered (viewport + overscan) flat-index range moves,
+	 * so the owner can page the covered books in (ensureBookRange).
+	 */
+	onVisibleRangeChange?: VisibleRangeChange;
 }
 
 export const BookGrid = ({
@@ -54,6 +63,7 @@ export const BookGrid = ({
 	selectedBookId,
 	scrollElementRef,
 	scrollToBookIndexRef,
+	onVisibleRangeChange,
 }: BookGridProps) => {
 	const actionsContext = useMemo(() => {
 		return {
@@ -69,6 +79,7 @@ export const BookGrid = ({
 				selectedBookId={selectedBookId}
 				scrollElementRef={scrollElementRef}
 				scrollToBookIndexRef={scrollToBookIndexRef}
+				onVisibleRangeChange={onVisibleRangeChange}
 			/>
 		</bookActionsContext.Provider>
 	);
@@ -80,12 +91,14 @@ const BookGridPure = ({
 	selectedBookId,
 	scrollElementRef,
 	scrollToBookIndexRef,
+	onVisibleRangeChange,
 }: {
 	loading: boolean;
-	bookList: LibraryBook[];
+	bookList: (LibraryBook | undefined)[];
 	selectedBookId?: LibraryBook["id"] | null;
 	scrollElementRef: RefObject<HTMLElement>;
 	scrollToBookIndexRef?: MutableRefObject<ScrollToBookIndex | null>;
+	onVisibleRangeChange?: VisibleRangeChange;
 }) => {
 	const actions = useContext(bookActionsContext);
 
@@ -136,6 +149,20 @@ const BookGridPure = ({
 		};
 	}, [scrollToBookIndexRef, virtualizer, columns]);
 
+	// Report the rendered row window (includes overscan) as a flat-index
+	// range so unfetched pages covering it can load.
+	const virtualRows = virtualizer.getVirtualItems();
+	const firstRow = virtualRows[0]?.index;
+	const lastRow = virtualRows[virtualRows.length - 1]?.index;
+	useEffect(() => {
+		if (!onVisibleRangeChange) return;
+		if (firstRow === undefined || lastRow === undefined) return;
+		const start = rowSlice(firstRow, columns, books.length).start;
+		const end = rowSlice(lastRow, columns, books.length).end - 1;
+		if (end < start) return;
+		onVisibleRangeChange(start, end);
+	}, [onVisibleRangeChange, firstRow, lastRow, columns, books.length]);
+
 	return (
 		<div
 			ref={wrapperRef}
@@ -159,7 +186,7 @@ const BookGridPure = ({
 				 * bottom-aligns its book (see BookCard.module.css) so the bases
 				 * sit on one line.
 				 */}
-				{virtualizer.getVirtualItems().map((virtualRow) => {
+				{virtualRows.map((virtualRow) => {
 					const { start, end } = rowSlice(
 						virtualRow.index,
 						columns,
@@ -182,14 +209,19 @@ const BookGridPure = ({
 								columnGap: COLUMN_GAP,
 							}}
 						>
-							{books.slice(start, end).map((book) => (
-								<BookCard
-									key={book.id}
-									book={book}
-									actions={actions}
-									selected={book.id === selectedBookId}
-								/>
-							))}
+							{books.slice(start, end).map((book, offset) =>
+								book !== undefined ? (
+									<BookCard
+										key={book.id}
+										book={book}
+										actions={actions}
+										selected={book.id === selectedBookId}
+									/>
+								) : (
+									// biome-ignore lint/suspicious/noArrayIndexKey: an unfetched slot has no id; its flat grid index IS its identity until the book arrives (and then the keyed BookCard replaces it).
+									<BookCardPlaceholder key={`placeholder-${start + offset}`} />
+								),
+							)}
 						</div>
 					);
 				})}
@@ -197,6 +229,17 @@ const BookGridPure = ({
 		</div>
 	);
 };
+
+/**
+ * Stand-in cell for a book whose page has not been fetched yet: the same
+ * shelf-cell layout as BookCard with a quiet cover-shaped block, so rows
+ * keep their height and books pop in without the shelf reflowing.
+ */
+const BookCardPlaceholder = () => (
+	<div className={cardClasses.cell} aria-hidden>
+		<span className={cardClasses.coverPlaceholder} />
+	</div>
+);
 
 type BookAction = (bookId: LibraryBook["id"]) => void;
 interface BookActionsContext {

--- a/src/components/organisms/AddBook.tsx
+++ b/src/components/organisms/AddBook.tsx
@@ -130,10 +130,10 @@ export const AddBookButton = () => {
 						}
 					},
 				});
-				// addBook/upsertBookIdentifier/updateBook already reload books;
-				// only a cover change happens outside the store's reloads.
+				// addBook/upsertBookIdentifier/updateBook already invalidate the
+				// book caches; only a cover change happens outside those.
 				if (pendingHardcover.image_url) {
-					await actions.loadBooks();
+					actions.invalidateBooks();
 				}
 			}
 			createdBookIdRef.current = null;

--- a/src/components/pages/Authors.tsx
+++ b/src/components/pages/Authors.tsx
@@ -21,10 +21,9 @@ import {
 } from "@/components/ui";
 import { useAuthorFilters } from "@/lib/hooks/use-author-filters";
 import {
+	useAllBooks,
 	useAuthors,
 	useAuthorsLoading,
-	useBooks,
-	useBooksLoading,
 	useLibraryActions,
 } from "@/stores/library/store";
 import { F7Pencil } from "../icons/F7Pencil";
@@ -45,8 +44,10 @@ const AUTHOR_GRID: CSSProperties = {
 export const Authors = () => {
 	const authors = useAuthors();
 	const loadingAuthors = useAuthorsLoading();
-	const books = useBooks();
-	const loadingBooks = useBooksLoading();
+	// Whole-library list (lazy): per-author book counts and the
+	// "authors without books" filter need every book↔author link, and no
+	// targeted per-author count query exists. See LibraryActions.loadBooks.
+	const { books, loading: loadingBooks } = useAllBooks();
 	const actions = useLibraryActions();
 
 	const {
@@ -311,7 +312,7 @@ const AuthorRow = ({
 			    own without stopPropagation. */}
 			<Link
 				to="/"
-				search={{ search_for_author: author.name }}
+				search={{ author_id: author.id }}
 				className="ctd-author-row-link"
 				aria-label={`Show books by ${author.name}`}
 			/>
@@ -334,7 +335,7 @@ const AuthorRow = ({
 
 			<Link
 				to="/"
-				search={{ search_for_author: author.name }}
+				search={{ author_id: author.id }}
 				className={styles.countLink}
 			>
 				{numBooksByAuthor}

--- a/src/components/pages/Books.tsx
+++ b/src/components/pages/Books.tsx
@@ -21,10 +21,19 @@ import {
 	Tooltip,
 } from "@/components/ui";
 import { safeAsyncEventHandler } from "@/lib/async";
+import { type BookGridFilter, sparseBookItems } from "@/lib/book-page-cache";
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value";
 import { useLibraryKeymap } from "@/lib/hooks/use-library-keymap";
 import { usePlatform } from "@/lib/platform/context";
 import { formatSeriesIndex } from "@/lib/series";
-import { useBooks, useBooksLoading } from "@/stores/library/store";
+import {
+	useAuthors,
+	useBookCache,
+	useLibraryActions,
+	useLibraryReady,
+	useLibraryTotal,
+	useSeriesList,
+} from "@/stores/library/store";
 import {
 	LibraryBookSortOrder,
 	type LibraryBookSortOrderKey,
@@ -39,8 +48,10 @@ import { BookGrid, type ScrollToBookIndex } from "../molecules/BookGrid";
 import styles from "./Books.module.css";
 
 interface BookSearchOptions {
-	search_for_author?: string;
-	search_for_series?: string;
+	/** Deep-link: only books by this author (LibraryAuthor id). */
+	author_id?: string;
+	/** Deep-link: only books in this series (LibrarySeries id). */
+	series_id?: number;
 }
 
 const SORT_LABELS: Record<LibraryBookSortOrderKey, string> = {
@@ -50,10 +61,14 @@ const SORT_LABELS: Record<LibraryBookSortOrderKey, string> = {
 	authorZa: "Author (Z–A)",
 };
 
-export const Books = ({
-	search_for_author,
-	search_for_series,
-}: BookSearchOptions) => {
+/**
+ * How long the search text must sit still before it becomes a new paged
+ * cache key (each distinct key costs backend fetches). The field itself
+ * stays instant; only the query is debounced.
+ */
+const QUERY_DEBOUNCE_MS = 200;
+
+export const Books = ({ author_id, series_id }: BookSearchOptions) => {
 	const query = useLibraryView((s) => s.query);
 	const sortOrder = useLibraryView((s) => s.sortOrder);
 	const hideRead = useLibraryView((s) => s.hideRead);
@@ -62,67 +77,73 @@ export const Books = ({
 	const setHideRead = useLibraryView((s) => s.setHideRead);
 	const resetToAllBooks = useLibraryView((s) => s.resetToAllBooks);
 
-	// Author deep-links (Authors page, drawer author names) fill the text
-	// query; reacting to the param means in-page clicks work too, while
-	// later hand-edits to the query stick.
-	useEffect(() => {
-		if (search_for_author) {
-			setQuery(search_for_author);
-		}
-	}, [search_for_author, setQuery]);
-
-	// A series link promises "the rest of this series in one click", so a
+	// An author or series link promises "those books in one click", so a
 	// text query from before the click must not keep filtering the results.
 	useEffect(() => {
-		if (search_for_series) {
+		if (author_id !== undefined || series_id !== undefined) {
 			setQuery("");
 		}
-	}, [search_for_series, setQuery]);
+	}, [author_id, series_id, setQuery]);
 
-	const books = useBooks();
-	const loading = useBooksLoading();
+	const actions = useLibraryActions();
+	const libraryReady = useLibraryReady();
+	const cache = useBookCache();
+	const libraryTotal = useLibraryTotal();
+	const authors = useAuthors();
+	const seriesList = useSeriesList();
+
+	const debouncedQuery = useDebouncedValue(query, QUERY_DEBOUNCE_MS);
+	const filter = useMemo<BookGridFilter>(
+		() => ({
+			text: debouncedQuery,
+			authorId: author_id ?? null,
+			seriesId: series_id ?? null,
+			hideRead,
+			sortOrder,
+		}),
+		[debouncedQuery, author_id, series_id, hideRead, sortOrder],
+	);
+
+	useEffect(() => {
+		if (!libraryReady) return;
+		actions.setBookFilter(filter);
+	}, [libraryReady, filter, actions]);
+
+	// The grid's last reported viewport; pages covering it are (re)fetched
+	// whenever the cache key or generation moves (filter change, mutation).
+	const lastRangeRef = useRef({ start: 0, end: 0 });
+	// biome-ignore lint/correctness/useExhaustiveDependencies: cache.key/cache.generation are triggers — a new filter or an invalidation must refetch the pages behind the current viewport.
+	useEffect(() => {
+		if (!libraryReady) return;
+		const { start, end } = lastRangeRef.current;
+		void actions.ensureBookRange(start, end);
+	}, [libraryReady, cache.key, cache.generation, actions]);
+
+	const onVisibleRangeChange = useCallback(
+		(start: number, end: number) => {
+			lastRangeRef.current = { start, end };
+			void actions.ensureBookRange(start, end);
+		},
+		[actions],
+	);
+
+	const books = useMemo(() => sparseBookItems(cache), [cache]);
+	const total = cache.total ?? 0;
+	const loading = !libraryReady || cache.total === null;
 
 	const navigate = useNavigate();
-	const onClearSeriesFilter = useCallback(() => {
+	const onClearDeepLinkFilter = useCallback(() => {
 		void navigate({ to: "/", search: {} });
 	}, [navigate]);
 
-	const filteredBooks = useMemo(() => {
-		const queryFiltered = filterBooksByQuery(books, { query, hideRead });
-		if (!search_for_series) return queryFiltered;
-		return queryFiltered.filter((book) => book.series === search_for_series);
-	}, [books, query, hideRead, search_for_series]);
-
-	const sortedBooks = useMemo(() => {
-		// An active series filter overrides the user's chosen sort order:
-		// books read best in series order.
-		if (search_for_series) {
-			return [...filteredBooks].sort(compareBySeriesIndex);
-		}
-
-		const compare = (a: LibraryBook, b: LibraryBook) => {
-			const authorA = a.author_list[0]?.sortable_name ?? "";
-			const authorB = b.author_list[0]?.sortable_name ?? "";
-
-			switch (sortOrder) {
-				case "authorAz":
-					return authorA.localeCompare(authorB);
-				case "authorZa":
-					return authorB.localeCompare(authorA);
-				case "nameAz":
-					return (a.sortable_title ?? a.title).localeCompare(
-						b.sortable_title ?? b.title,
-					);
-				case "nameZa":
-					return (b.sortable_title ?? b.title).localeCompare(
-						a.sortable_title ?? a.title,
-					);
-				default:
-					return 0;
-			}
-		};
-		return [...filteredBooks].sort(compare);
-	}, [filteredBooks, sortOrder, search_for_series]);
+	const authorTokenName =
+		author_id !== undefined
+			? (authors.find((author) => author.id === author_id)?.name ?? "Author")
+			: undefined;
+	const seriesTokenName =
+		series_id !== undefined
+			? (seriesList.find((series) => series.id === series_id)?.name ?? "Series")
+			: undefined;
 
 	const [isBookSidebarOpen, setIsBookSidebarOpen] = useState(false);
 
@@ -130,7 +151,9 @@ export const Books = ({
 		useState<LibraryBook | null>(null);
 	const onBookOpen = useCallback(
 		(bookId: LibraryBook["id"]) => {
-			const book = books.filter((book) => book.id === bookId).at(0);
+			const book = books.find(
+				(candidate) => candidate !== undefined && candidate.id === bookId,
+			);
 			if (!book) return;
 			setSelectedSidebarBook(book);
 			setIsBookSidebarOpen(true);
@@ -145,7 +168,8 @@ export const Books = ({
 	const scrollToBookIndexRef = useRef<ScrollToBookIndex | null>(null);
 
 	const { selectedBookId } = useLibraryKeymap({
-		books: sortedBooks,
+		books,
+		resetToken: cache.key,
 		drawerOpened: isBookSidebarOpen,
 		searchInputRef,
 		gridContainerRef,
@@ -154,7 +178,29 @@ export const Books = ({
 		onClearSearch: () => setQuery(""),
 	});
 
-	const noMatches = !loading && sortedBooks.length === 0 && books.length > 0;
+	const noMatches = !loading && total === 0 && (libraryTotal ?? 0) > 0;
+
+	const searchTokens = [
+		...(authorTokenName !== undefined
+			? [
+					{
+						label: `Author: ${authorTokenName}`,
+						onRemove: onClearDeepLinkFilter,
+						title: "Showing only books by this author",
+					},
+				]
+			: []),
+		...(seriesTokenName !== undefined
+			? [
+					{
+						label: `Series: ${seriesTokenName}`,
+						onRemove: onClearDeepLinkFilter,
+						title:
+							"Books are sorted in series order while this filter is active",
+					},
+				]
+			: []),
+	];
 
 	return (
 		<div className={styles.page}>
@@ -166,23 +212,12 @@ export const Books = ({
 				<span className={styles.searchWrap}>
 					<SearchField
 						ref={searchInputRef}
-						placeholder={search_for_series !== undefined ? undefined : "Search"}
+						placeholder={searchTokens.length > 0 ? undefined : "Search"}
 						aria-label="Search book titles and authors"
 						value={query}
 						onChange={(event) => setQuery(event.currentTarget.value)}
 						className={styles.searchInput}
-						tokens={
-							search_for_series !== undefined
-								? [
-										{
-											label: `Series: ${search_for_series}`,
-											onRemove: onClearSeriesFilter,
-											title:
-												"Books are sorted in series order while this filter is active",
-										},
-									]
-								: undefined
-						}
+						tokens={searchTokens.length > 0 ? searchTokens : undefined}
 					/>
 				</span>
 				<Select
@@ -196,7 +231,7 @@ export const Books = ({
 					}))}
 					value={sortOrder}
 					onChange={(value) => setSortOrder(value as LibraryBookSortOrderKey)}
-					disabled={search_for_series !== undefined}
+					disabled={series_id !== undefined}
 				/>
 				<Checkbox
 					label="Unread only"
@@ -220,26 +255,35 @@ export const Books = ({
 						<span className={styles.emptyText}>
 							No books match these filters.
 						</span>
-						<Button variant="subtle" onClick={() => resetToAllBooks()}>
+						<Button
+							variant="subtle"
+							onClick={() => {
+								resetToAllBooks();
+								onClearDeepLinkFilter();
+							}}
+						>
 							Show all books
 						</Button>
 					</div>
 				) : (
 					<BookGrid
-						bookList={sortedBooks}
+						bookList={books}
 						loading={loading}
 						onBookOpen={onBookOpen}
 						selectedBookId={selectedBookId}
 						scrollElementRef={gridContainerRef}
 						scrollToBookIndexRef={scrollToBookIndexRef}
+						onVisibleRangeChange={onVisibleRangeChange}
 					/>
 				)}
 			</div>
 			<div className={styles.footer}>
 				<span className={styles.footerText}>
-					{sortedBooks.length === books.length
-						? `${books.length} books`
-						: `${sortedBooks.length} of ${books.length} books`}
+					{loading
+						? "Loading books…"
+						: libraryTotal === null || total === libraryTotal
+							? `${total} books`
+							: `${total} of ${libraryTotal} books`}
 				</span>
 			</div>
 			<Drawer
@@ -397,6 +441,15 @@ const BookDetails = ({
 	const platform = usePlatform();
 	const navigate = useNavigate();
 	const canRead = platform.capabilities.canOpenLocalPaths;
+	// Books carry only their series NAME; the id that LibraryBookQuery
+	// filters on comes from the store's series list (loaded at init and
+	// refreshed on mutations). An unresolvable name (shouldn't happen)
+	// degrades to plain text.
+	const seriesList = useSeriesList();
+	const seriesId =
+		book.series !== null
+			? seriesList.find((series) => series.name === book.series)?.id
+			: undefined;
 	return (
 		<div className={styles.details}>
 			<div className={styles.detailsTop}>
@@ -410,7 +463,7 @@ const BookDetails = ({
 									{index > 0 && ", "}
 									<Link
 										to="/"
-										search={{ search_for_author: author.name }}
+										search={{ author_id: author.id }}
 										onClick={onClose}
 										className={styles.detailsLink}
 									>
@@ -424,14 +477,18 @@ const BookDetails = ({
 								{book.series_index !== null
 									? `Book ${formatSeriesIndex(book.series_index)} of `
 									: "Part of "}
-								<Link
-									to="/"
-									search={{ search_for_series: book.series }}
-									onClick={onClose}
-									className={styles.detailsLink}
-								>
-									{book.series}
-								</Link>
+								{seriesId !== undefined ? (
+									<Link
+										to="/"
+										search={{ series_id: seriesId }}
+										onClick={onClose}
+										className={styles.detailsLink}
+									>
+										{book.series}
+									</Link>
+								) : (
+									book.series
+								)}
 							</span>
 						)}
 					</div>
@@ -612,24 +669,3 @@ export interface BookViewOptions {
 	sortOrder: "authorAz" | "authorZa" | "nameAz" | "nameZa";
 	searchQuery: string;
 }
-
-const compareBySeriesIndex = (a: LibraryBook, b: LibraryBook): number => {
-	const indexA = a.series_index ?? Number.POSITIVE_INFINITY;
-	const indexB = b.series_index ?? Number.POSITIVE_INFINITY;
-	if (indexA !== indexB) return indexA - indexB;
-	return a.title.localeCompare(b.title);
-};
-
-const filterBooksByQuery = (
-	books: LibraryBook[],
-	{ query, hideRead }: { query: string; hideRead: boolean },
-) => {
-	const lowerQuery = query.toLowerCase();
-	return books
-		.filter(
-			({ title, author_list }) =>
-				title.toLowerCase().includes(lowerQuery) ||
-				author_list.some(({ name }) => name.toLowerCase().includes(lowerQuery)),
-		)
-		.filter((book) => (hideRead ? !book.is_read : true));
-};

--- a/src/components/pages/Series.tsx
+++ b/src/components/pages/Series.tsx
@@ -2,9 +2,9 @@ import { Link } from "@tanstack/react-router";
 import clsx from "clsx";
 import { type CSSProperties, useMemo, useState } from "react";
 
+import type { LibrarySeries } from "@/bindings";
 import { SearchField } from "@/components/ui";
-import { deriveSeriesSummaries, type SeriesSummary } from "@/lib/series";
-import { useBooks, useBooksLoading } from "@/stores/library/store";
+import { useSeriesList, useSeriesLoading } from "@/stores/library/store";
 import styles from "./Series.module.css";
 
 /**
@@ -19,21 +19,21 @@ const SERIES_GRID: CSSProperties = {
 };
 
 export const Series = () => {
-	const books = useBooks();
-	const loadingBooks = useBooksLoading();
+	// The store's series list (clb_query_list_series) arrives sorted by name
+	// with book counts; no need to derive it from the full book list.
+	const seriesList = useSeriesList();
+	const loadingSeries = useSeriesLoading();
 
 	const [searchTerm, setSearchTerm] = useState("");
 
-	const seriesSummaries = useMemo(() => deriveSeriesSummaries(books), [books]);
-
 	const filteredSeries = useMemo(() => {
 		const lowerSearch = searchTerm.toLowerCase();
-		return seriesSummaries.filter(({ name }) =>
+		return seriesList.filter(({ name }) =>
 			name.toLowerCase().includes(lowerSearch),
 		);
-	}, [seriesSummaries, searchTerm]);
+	}, [seriesList, searchTerm]);
 
-	if (loadingBooks) {
+	if (loadingSeries) {
 		return null;
 	}
 
@@ -58,22 +58,22 @@ export const Series = () => {
 
 			<div className={styles.rows}>
 				{filteredSeries.map((series) => (
-					<SeriesRow series={series} key={series.name} />
+					<SeriesRow series={series} key={series.id} />
 				))}
 			</div>
 
 			<div className={styles.footer}>
 				<span className={styles.footerText}>
-					{filteredSeries.length === seriesSummaries.length
-						? `${seriesSummaries.length} series`
-						: `${filteredSeries.length} of ${seriesSummaries.length} series`}
+					{filteredSeries.length === seriesList.length
+						? `${seriesList.length} series`
+						: `${filteredSeries.length} of ${seriesList.length} series`}
 				</span>
 			</div>
 		</div>
 	);
 };
 
-const SeriesRow = ({ series }: { series: SeriesSummary }) => {
+const SeriesRow = ({ series }: { series: LibrarySeries }) => {
 	return (
 		// The whole row links to the library filtered by this series. The hover
 		// background, 40px min-height, and the overlay-link positioning live in
@@ -84,7 +84,7 @@ const SeriesRow = ({ series }: { series: SeriesSummary }) => {
 			    relative + zIndex), so it keeps working without stopPropagation. */}
 			<Link
 				to="/"
-				search={{ search_for_series: series.name }}
+				search={{ series_id: series.id }}
 				className="ctd-author-row-link"
 				aria-label={`Show books in ${series.name}`}
 			/>
@@ -93,10 +93,10 @@ const SeriesRow = ({ series }: { series: SeriesSummary }) => {
 
 			<Link
 				to="/"
-				search={{ search_for_series: series.name }}
+				search={{ series_id: series.id }}
 				className={styles.countLink}
 			>
-				{series.bookCount}
+				{series.book_count}
 			</Link>
 		</div>
 	);

--- a/src/lib/book-page-cache.test.ts
+++ b/src/lib/book-page-cache.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+import type { LibraryBook } from "@/bindings";
+import {
+	applyBookPage,
+	BOOK_PAGE_SIZE,
+	type BookGridFilter,
+	cacheForKey,
+	compareBySeriesIndex,
+	emptyBookCache,
+	invalidateBookCache,
+	pagesCoveringRange,
+	serializeBookFilter,
+	sparseBookItems,
+	toBookQuery,
+} from "./book-page-cache";
+
+const book = (id: string, extra: Partial<LibraryBook> = {}): LibraryBook => ({
+	id,
+	uuid: null,
+	title: `Book ${id}`,
+	author_list: [],
+	tag_list: [],
+	sortable_title: null,
+	file_list: [],
+	cover_image: null,
+	identifier_list: [],
+	description: null,
+	is_read: false,
+	series: null,
+	series_index: null,
+	...extra,
+});
+
+const filter = (overrides: Partial<BookGridFilter> = {}): BookGridFilter => ({
+	text: "",
+	authorId: null,
+	seriesId: null,
+	hideRead: false,
+	sortOrder: "authorAz",
+	...overrides,
+});
+
+describe("serializeBookFilter", () => {
+	it("treats empty and whitespace-only text as the same key", () => {
+		expect(serializeBookFilter(filter({ text: "" }))).toBe(
+			serializeBookFilter(filter({ text: "   " })),
+		);
+	});
+
+	it("trims text so padding does not fork the cache", () => {
+		expect(serializeBookFilter(filter({ text: " dune " }))).toBe(
+			serializeBookFilter(filter({ text: "dune" })),
+		);
+	});
+
+	it("changes when any filter dimension changes", () => {
+		const base = serializeBookFilter(filter());
+		expect(serializeBookFilter(filter({ text: "dune" }))).not.toBe(base);
+		expect(serializeBookFilter(filter({ authorId: "7" }))).not.toBe(base);
+		expect(serializeBookFilter(filter({ seriesId: 3 }))).not.toBe(base);
+		expect(serializeBookFilter(filter({ hideRead: true }))).not.toBe(base);
+		expect(serializeBookFilter(filter({ sortOrder: "nameZa" }))).not.toBe(base);
+	});
+});
+
+describe("toBookQuery", () => {
+	it("maps page index to limit/offset and sort keys to backend orders", () => {
+		const query = toBookQuery(filter({ sortOrder: "nameZa" }), 3, 50);
+		expect(query).toMatchObject({
+			text: null,
+			sort: "TitleDesc",
+			limit: 50,
+			offset: 150,
+		});
+	});
+
+	it("maps every sort order", () => {
+		expect(toBookQuery(filter({ sortOrder: "nameAz" }), 0).sort).toBe(
+			"TitleAsc",
+		);
+		expect(toBookQuery(filter({ sortOrder: "nameZa" }), 0).sort).toBe(
+			"TitleDesc",
+		);
+		expect(toBookQuery(filter({ sortOrder: "authorAz" }), 0).sort).toBe(
+			"AuthorAsc",
+		);
+		expect(toBookQuery(filter({ sortOrder: "authorZa" }), 0).sort).toBe(
+			"AuthorDesc",
+		);
+	});
+
+	it("nullifies blank text and passes trimmed text through", () => {
+		expect(toBookQuery(filter({ text: "  " }), 0).text).toBeNull();
+		expect(toBookQuery(filter({ text: " dune " }), 0).text).toBe("dune");
+	});
+
+	it("fetches a whole series as one unbounded page", () => {
+		const query = toBookQuery(filter({ seriesId: 9 }), 2, 50);
+		expect(query.series_id).toBe(9);
+		expect(query.limit).toBeNull();
+		expect(query.offset).toBe(0);
+	});
+});
+
+describe("pagesCoveringRange", () => {
+	it("maps an index range to the pages containing it", () => {
+		expect(pagesCoveringRange(0, 99, 100)).toEqual([0]);
+		expect(pagesCoveringRange(99, 100, 100)).toEqual([0, 1]);
+		expect(pagesCoveringRange(250, 460, 100)).toEqual([2, 3, 4]);
+	});
+
+	it("clamps to the known total", () => {
+		expect(pagesCoveringRange(80, 500, 100, 120)).toEqual([0, 1]);
+		expect(pagesCoveringRange(200, 300, 100, 120)).toEqual([]);
+	});
+
+	it("does not clamp the end while the total is unknown", () => {
+		expect(pagesCoveringRange(0, 150, 100, null)).toEqual([0, 1]);
+	});
+
+	it("returns no pages for empty or negative ranges", () => {
+		expect(pagesCoveringRange(10, 5, 100)).toEqual([]);
+		expect(pagesCoveringRange(-20, -1, 100)).toEqual([]);
+		expect(pagesCoveringRange(0, 10, 100, 0)).toEqual([]);
+	});
+
+	it("clamps negative starts to page zero", () => {
+		expect(pagesCoveringRange(-5, 10, 100)).toEqual([0]);
+	});
+});
+
+describe("cacheForKey", () => {
+	it("keeps the cache when the key is unchanged", () => {
+		const cache = emptyBookCache("a", 1);
+		expect(cacheForKey(cache, "a")).toBe(cache);
+	});
+
+	it("starts an empty cache under the next generation for a new key", () => {
+		const cache = applyBookPage(emptyBookCache("a", 1), {
+			key: "a",
+			generation: 1,
+			pageIndex: 0,
+			items: [book("1")],
+			total: 1,
+		});
+		const next = cacheForKey(cache, "b");
+		expect(next.key).toBe("b");
+		expect(next.generation).toBe(2);
+		expect(next.total).toBeNull();
+		expect(next.pages.size).toBe(0);
+	});
+});
+
+describe("applyBookPage / generation invalidation", () => {
+	const loaded = () =>
+		applyBookPage(emptyBookCache("a", 1), {
+			key: "a",
+			generation: 1,
+			pageIndex: 0,
+			items: [book("1"), book("2")],
+			total: 5,
+		});
+
+	it("lands a page and learns the total", () => {
+		const cache = loaded();
+		expect(cache.total).toBe(5);
+		expect(cache.pages.get(0)?.map((b) => b.id)).toEqual(["1", "2"]);
+	});
+
+	it("drops results from a superseded key", () => {
+		const cache = loaded();
+		const next = applyBookPage(cache, {
+			key: "b",
+			generation: 1,
+			pageIndex: 1,
+			items: [book("9")],
+			total: 9,
+		});
+		expect(next).toBe(cache);
+	});
+
+	it("drops results from a superseded generation", () => {
+		const invalidated = invalidateBookCache(loaded());
+		const next = applyBookPage(invalidated, {
+			key: "a",
+			generation: 1, // started before the invalidation
+			pageIndex: 0,
+			items: [book("stale")],
+			total: 5,
+		});
+		expect(next).toBe(invalidated);
+		expect(next.pages.size).toBe(0);
+	});
+
+	it("invalidation clears pages but keeps the key and total", () => {
+		const cache = invalidateBookCache(loaded());
+		expect(cache.key).toBe("a");
+		expect(cache.generation).toBe(2);
+		expect(cache.total).toBe(5);
+		expect(cache.pages.size).toBe(0);
+	});
+
+	it("accepts pages fetched under the post-invalidation generation", () => {
+		const cache = invalidateBookCache(loaded());
+		const next = applyBookPage(cache, {
+			key: "a",
+			generation: 2,
+			pageIndex: 0,
+			items: [book("fresh")],
+			total: 4,
+		});
+		expect(next.total).toBe(4);
+		expect(next.pages.get(0)?.[0]?.id).toBe("fresh");
+	});
+});
+
+describe("sparseBookItems", () => {
+	it("places pages at their flat offsets and leaves holes undefined", () => {
+		let cache = emptyBookCache("a", 1);
+		cache = applyBookPage(cache, {
+			key: "a",
+			generation: 1,
+			pageIndex: 1,
+			items: [book("3"), book("4")],
+			total: 5,
+		});
+		const items = sparseBookItems(cache, 2);
+		expect(items).toHaveLength(5);
+		expect(items[0]).toBeUndefined();
+		expect(items[1]).toBeUndefined();
+		expect(items[2]?.id).toBe("3");
+		expect(items[3]?.id).toBe("4");
+		expect(items[4]).toBeUndefined();
+	});
+
+	it("is empty while the total is unknown", () => {
+		expect(sparseBookItems(emptyBookCache("a", 1))).toEqual([]);
+	});
+
+	it("ignores items beyond the total (shrunk filter results)", () => {
+		let cache = emptyBookCache("a", 1);
+		cache = applyBookPage(cache, {
+			key: "a",
+			generation: 1,
+			pageIndex: 0,
+			items: [book("1"), book("2"), book("3")],
+			total: 2,
+		});
+		expect(sparseBookItems(cache, BOOK_PAGE_SIZE)).toHaveLength(2);
+	});
+
+	it("supports an oversized series page at page zero", () => {
+		let cache = emptyBookCache("a", 1);
+		cache = applyBookPage(cache, {
+			key: "a",
+			generation: 1,
+			pageIndex: 0,
+			items: [book("1"), book("2"), book("3")],
+			total: 3,
+		});
+		// Page size 2, but the series special case lands everything in page 0.
+		const items = sparseBookItems(cache, 2);
+		expect(items.map((item) => item?.id)).toEqual(["1", "2", "3"]);
+	});
+});
+
+describe("compareBySeriesIndex", () => {
+	it("orders by series index, pushing index-less books last", () => {
+		const books = [
+			book("c", { series_index: null }),
+			book("b", { series_index: 2 }),
+			book("a", { series_index: 1 }),
+		];
+		expect([...books].sort(compareBySeriesIndex).map((b) => b.id)).toEqual([
+			"a",
+			"b",
+			"c",
+		]);
+	});
+
+	it("breaks index ties by title", () => {
+		const books = [
+			book("z", { title: "Zeta", series_index: 1 }),
+			book("a", { title: "Alpha", series_index: 1 }),
+		];
+		expect([...books].sort(compareBySeriesIndex).map((b) => b.id)).toEqual([
+			"a",
+			"z",
+		]);
+	});
+});

--- a/src/lib/book-page-cache.ts
+++ b/src/lib/book-page-cache.ts
@@ -1,0 +1,211 @@
+/**
+ * Pure logic for the library's paged book cache (stores/library/store.ts).
+ *
+ * The cover grid no longer holds every book in memory: it keeps one cache
+ * entry per filter combination (the serialized cache key) holding the total
+ * match count plus a sparse map of fetched pages. Everything here is plain
+ * data-in/data-out so it can be unit-tested without Tauri.
+ */
+
+import type { BookSortOrder, LibraryBook, LibraryBookQuery } from "@/bindings";
+import type { LibraryBookSortOrderKey } from "@/lib/platform/settings/types";
+
+/**
+ * Books fetched per page. 100 covers is 10–25 virtualized shelf rows
+ * (4–10 columns per row), i.e. several viewports of scrolling per fetch,
+ * while one page of fully hydrated books stays a small IPC payload.
+ */
+export const BOOK_PAGE_SIZE = 100;
+
+/** The grid's filter state; one cache key per distinct combination. */
+export interface BookGridFilter {
+	/** Raw search text (debounced upstream); trimmed for the query/key. */
+	text: string;
+	authorId: string | null;
+	seriesId: number | null;
+	hideRead: boolean;
+	sortOrder: LibraryBookSortOrderKey;
+}
+
+export const ALL_BOOKS_FILTER: BookGridFilter = {
+	text: "",
+	authorId: null,
+	seriesId: null,
+	hideRead: false,
+	sortOrder: "authorAz",
+};
+
+const SORT_ORDER_TO_BACKEND: Record<LibraryBookSortOrderKey, BookSortOrder> = {
+	nameAz: "TitleAsc",
+	nameZa: "TitleDesc",
+	authorAz: "AuthorAsc",
+	authorZa: "AuthorDesc",
+};
+
+const normalizedText = (filter: BookGridFilter): string | null => {
+	const trimmed = filter.text.trim();
+	return trimmed.length > 0 ? trimmed : null;
+};
+
+/**
+ * Cache key for a filter combination. Sorting is part of the key: a page
+ * fetched under one sort order holds different indices under another.
+ */
+export const serializeBookFilter = (filter: BookGridFilter): string =>
+	JSON.stringify([
+		normalizedText(filter),
+		filter.authorId,
+		filter.seriesId,
+		filter.hideRead,
+		filter.sortOrder,
+	]);
+
+/**
+ * The backend query for one page of a filter.
+ *
+ * Series filters are special-cased to a single unbounded page: books in a
+ * series read in series order, but the backend only sorts by title/author
+ * (Calibre sort columns), so the whole series is fetched at once and sorted
+ * by `series_index` client-side. Series are small (rarely more than a few
+ * dozen books), so this stays cheap.
+ */
+export const toBookQuery = (
+	filter: BookGridFilter,
+	pageIndex: number,
+	pageSize: number = BOOK_PAGE_SIZE,
+): LibraryBookQuery => ({
+	text: normalizedText(filter),
+	author_id: filter.authorId,
+	series_id: filter.seriesId,
+	hide_read: filter.hideRead,
+	sort: SORT_ORDER_TO_BACKEND[filter.sortOrder],
+	limit: filter.seriesId !== null ? null : pageSize,
+	offset: filter.seriesId !== null ? 0 : pageIndex * pageSize,
+});
+
+/**
+ * Page indices covering the inclusive item-index range [start, end].
+ * The range is clamped to [0, total) when the total is known; an unknown
+ * total (nothing fetched yet) clamps nothing so page 0 can be requested.
+ */
+export const pagesCoveringRange = (
+	start: number,
+	end: number,
+	pageSize: number = BOOK_PAGE_SIZE,
+	total: number | null = null,
+): number[] => {
+	const clampedStart = Math.max(start, 0);
+	const clampedEnd = total === null ? end : Math.min(end, total - 1);
+	if (clampedEnd < clampedStart) return [];
+
+	const firstPage = Math.floor(clampedStart / pageSize);
+	const lastPage = Math.floor(clampedEnd / pageSize);
+	const pages: number[] = [];
+	for (let page = firstPage; page <= lastPage; page++) {
+		pages.push(page);
+	}
+	return pages;
+};
+
+/** One filter combination's pages. */
+export interface PagedBookCache {
+	/** Serialized [`BookGridFilter`] the pages belong to. */
+	key: string;
+	/**
+	 * Monotonic stamp. Fetch results may only land while the generation they
+	 * started under is still current; mutations bump it to drop stale pages.
+	 */
+	generation: number;
+	/** Total matches for the filter; null until the first page lands. */
+	total: number | null;
+	/** Sparse page-index → fetched books. */
+	pages: ReadonlyMap<number, LibraryBook[]>;
+}
+
+export const emptyBookCache = (
+	key: string,
+	generation: number,
+): PagedBookCache => ({
+	key,
+	generation,
+	total: null,
+	pages: new Map(),
+});
+
+/**
+ * The cache to use for a (possibly new) filter key: the same cache when the
+ * key matches, otherwise a fresh empty cache under the next generation.
+ */
+export const cacheForKey = (
+	cache: PagedBookCache,
+	key: string,
+): PagedBookCache =>
+	cache.key === key ? cache : emptyBookCache(key, cache.generation + 1);
+
+/**
+ * Drops every fetched page and bumps the generation (cancelling in-flight
+ * fetches), keeping the key and the last known total so the grid keeps its
+ * height while visible pages refetch lazily. Used after mutations.
+ */
+export const invalidateBookCache = (cache: PagedBookCache): PagedBookCache => ({
+	key: cache.key,
+	generation: cache.generation + 1,
+	total: cache.total,
+	pages: new Map(),
+});
+
+export interface FetchedBookPage {
+	key: string;
+	generation: number;
+	pageIndex: number;
+	items: LibraryBook[];
+	total: number;
+}
+
+/**
+ * Lands one fetched page. Results from a superseded key or generation are
+ * dropped (the cache is returned unchanged).
+ */
+export const applyBookPage = (
+	cache: PagedBookCache,
+	fetched: FetchedBookPage,
+): PagedBookCache => {
+	if (fetched.key !== cache.key || fetched.generation !== cache.generation) {
+		return cache;
+	}
+	const pages = new Map(cache.pages);
+	pages.set(fetched.pageIndex, fetched.items);
+	return { ...cache, total: fetched.total, pages };
+};
+
+/**
+ * The cache flattened to the grid's indexed-array shape: length `total`,
+ * `undefined` holes where pages have not been fetched.
+ */
+export const sparseBookItems = (
+	cache: PagedBookCache,
+	pageSize: number = BOOK_PAGE_SIZE,
+): (LibraryBook | undefined)[] => {
+	const total = cache.total ?? 0;
+	const items = new Array<LibraryBook | undefined>(total).fill(undefined);
+	for (const [pageIndex, pageItems] of cache.pages) {
+		const offset = pageIndex * pageSize;
+		for (let i = 0; i < pageItems.length; i++) {
+			const index = offset + i;
+			if (index >= total) break;
+			items[index] = pageItems[i];
+		}
+	}
+	return items;
+};
+
+/** Series-order comparator (used when a series filter is active). */
+export const compareBySeriesIndex = (
+	a: LibraryBook,
+	b: LibraryBook,
+): number => {
+	const indexA = a.series_index ?? Number.POSITIVE_INFINITY;
+	const indexB = b.series_index ?? Number.POSITIVE_INFINITY;
+	if (indexA !== indexB) return indexA - indexB;
+	return a.title.localeCompare(b.title);
+};

--- a/src/lib/hooks/use-debounced-value.ts
+++ b/src/lib/hooks/use-debounced-value.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `value`, but only after it has been stable for `delayMs`.
+ *
+ * Used to keep the library search field instant while the debounced text is
+ * what becomes a new paged-query cache key (each distinct key costs a
+ * backend fetch).
+ */
+export const useDebouncedValue = <TValue>(
+	value: TValue,
+	delayMs: number,
+): TValue => {
+	const [debounced, setDebounced] = useState(value);
+
+	useEffect(() => {
+		const timer = window.setTimeout(() => setDebounced(value), delayMs);
+		return () => window.clearTimeout(timer);
+	}, [value, delayMs]);
+
+	return debounced;
+};

--- a/src/lib/hooks/use-library-keymap.ts
+++ b/src/lib/hooks/use-library-keymap.ts
@@ -1,11 +1,24 @@
-import { type RefObject, useState } from "react";
+import { type RefObject, useEffect, useState } from "react";
 import type { LibraryBook } from "@/bindings";
 import { useKeymap } from "@/lib/hooks/use-keymap";
 import type { KeyBinding, SelectionDirection } from "@/lib/keymap";
 import { moveSelection } from "@/lib/keymap";
 
 interface LibraryKeymapOptions {
-	books: LibraryBook[];
+	/**
+	 * Indexed view of the filtered library: length is the total match count,
+	 * `undefined` entries are books whose page has not been fetched yet.
+	 * Selection tracks the INDEX, so arrow keys can move onto an unfetched
+	 * slot; the scroll-into-view below makes its page load, and the
+	 * selection ring appears once the book arrives.
+	 */
+	books: (LibraryBook | undefined)[];
+	/**
+	 * Identity of the filter behind `books` (the paged cache key). Selection
+	 * is positional, so it resets when the filter changes — index 4 of a new
+	 * result set is an unrelated book.
+	 */
+	resetToken?: string;
 	drawerOpened: boolean;
 	searchInputRef: RefObject<HTMLInputElement>;
 	gridContainerRef: RefObject<HTMLElement>;
@@ -39,6 +52,7 @@ const measureColumns = (container: HTMLElement | null): number => {
 
 export const useLibraryKeymap = ({
 	books,
+	resetToken,
 	drawerOpened,
 	searchInputRef,
 	gridContainerRef,
@@ -46,47 +60,51 @@ export const useLibraryKeymap = ({
 	onBookOpen,
 	onClearSearch,
 }: LibraryKeymapOptions): { selectedBookId: LibraryBook["id"] | null } => {
-	const [selectedBookId, setSelectedBookId] = useState<
-		LibraryBook["id"] | null
-	>(null);
+	const [selectedIndex, setSelectedIndex] = useState<number>(-1);
 
-	const selectedIndex =
-		selectedBookId === null
-			? -1
-			: books.findIndex((book) => book.id === selectedBookId);
-	const visibleSelectedBookId = selectedIndex >= 0 ? selectedBookId : null;
+	// New filter, new result set: positional selection no longer points at
+	// the book the user picked.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: resetToken exists solely to trigger this reset.
+	useEffect(() => {
+		setSelectedIndex(-1);
+	}, [resetToken]);
 
-	const selectBook = (book: LibraryBook, index: number) => {
-		setSelectedBookId(book.id);
+	const inRange = selectedIndex >= 0 && selectedIndex < books.length;
+	const selectedBook = inRange ? books[selectedIndex] : undefined;
+	const visibleSelectedBookId = selectedBook?.id ?? null;
+
+	const selectIndex = (index: number) => {
+		setSelectedIndex(index);
 		// The grid is virtualized: the target row may not be mounted, so ask
-		// the virtualizer to scroll it into view first. When the card is
-		// already mounted, the follow-up scrollIntoView fine-tunes alignment;
-		// when it is not, the row-level scroll alone places it in view and the
-		// card renders selected on the next frame.
+		// the virtualizer to scroll it into view first (which also pages the
+		// books covering it in). When the card is already mounted, the
+		// follow-up scrollIntoView fine-tunes alignment; when it is not, the
+		// row-level scroll alone places it in view and the card renders
+		// selected once its book arrives.
 		scrollToBookIndexRef?.current?.(index);
-		document
-			.querySelector(`[data-book-id="${CSS.escape(book.id)}"]`)
-			?.scrollIntoView({ block: "nearest" });
+		const book = books[index];
+		if (book !== undefined) {
+			document
+				.querySelector(`[data-book-id="${CSS.escape(book.id)}"]`)
+				?.scrollIntoView({ block: "nearest" });
+		}
 	};
 
 	const moveBy = (direction: SelectionDirection) => {
 		const nextIndex = moveSelection({
-			index: selectedIndex,
+			index: inRange ? selectedIndex : -1,
 			count: books.length,
 			columns: measureColumns(gridContainerRef.current),
 			direction,
 		});
-		if (nextIndex < 0) return;
-		const nextBook = books[nextIndex];
-		if (nextBook === undefined) return;
-		selectBook(nextBook, nextIndex);
+		if (nextIndex < 0 || nextIndex >= books.length) return;
+		selectIndex(nextIndex);
 	};
 
 	// Spotlight-style hand-off: commit the query and drop into the results.
 	const leaveSearchForGrid = () => {
 		gridContainerRef.current?.focus();
-		const firstBook = books[0];
-		if (firstBook !== undefined) selectBook(firstBook, 0);
+		if (books.length > 0) selectIndex(0);
 	};
 
 	const bindings: KeyBinding[] = [];

--- a/src/lib/series.test.ts
+++ b/src/lib/series.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveSeriesSummaries, formatSeriesIndex } from "./series";
+import { formatSeriesIndex } from "./series";
 
 describe("formatSeriesIndex", () => {
 	it("formats whole indices without a trailing .0", () => {
@@ -15,37 +15,5 @@ describe("formatSeriesIndex", () => {
 
 	it("rounds away f32 float noise", () => {
 		expect(formatSeriesIndex(0.10000000149011612)).toBe("0.1");
-	});
-});
-
-describe("deriveSeriesSummaries", () => {
-	it("groups books by series and counts them", () => {
-		const books = [
-			{ series: "Discworld" },
-			{ series: "Discworld" },
-			{ series: "Culture" },
-			{ series: null },
-		];
-
-		expect(deriveSeriesSummaries(books)).toEqual([
-			{ name: "Culture", bookCount: 1 },
-			{ name: "Discworld", bookCount: 2 },
-		]);
-	});
-
-	it("ignores books without a series", () => {
-		expect(deriveSeriesSummaries([{ series: null }, { series: null }])).toEqual(
-			[],
-		);
-	});
-
-	it("sorts series alphabetically", () => {
-		const books = [{ series: "Zeta" }, { series: "Alpha" }, { series: "Mu" }];
-
-		expect(deriveSeriesSummaries(books).map(({ name }) => name)).toEqual([
-			"Alpha",
-			"Mu",
-			"Zeta",
-		]);
 	});
 });

--- a/src/lib/series.ts
+++ b/src/lib/series.ts
@@ -1,10 +1,3 @@
-import type { LibraryBook } from "@/bindings";
-
-export interface SeriesSummary {
-	name: string;
-	bookCount: number;
-}
-
 /**
  * Formats a series index for display, without a trailing ".0". Indices are
  * stored as f32 in Calibre, so values are rounded to two decimals to hide
@@ -18,21 +11,3 @@ export interface SeriesSummary {
  */
 export const formatSeriesIndex = (seriesIndex: number): string =>
 	String(Math.round(seriesIndex * 100) / 100);
-
-/**
- * Derives the list of series in a library from its books, with a book count
- * per series, sorted alphabetically by series name.
- */
-export const deriveSeriesSummaries = (
-	books: Pick<LibraryBook, "series">[],
-): SeriesSummary[] => {
-	const bookCountBySeries = new Map<string, number>();
-	for (const { series } of books) {
-		if (series === null) continue;
-		bookCountBySeries.set(series, (bookCountBySeries.get(series) ?? 0) + 1);
-	}
-
-	return [...bookCountBySeries.entries()]
-		.map(([name, bookCount]) => ({ name, bookCount }))
-		.sort((a, b) => a.name.localeCompare(b.name));
-};

--- a/src/lib/services/library/_internal/_types.ts
+++ b/src/lib/services/library/_internal/_types.ts
@@ -5,6 +5,9 @@ import type {
 	ImportableFile,
 	LibraryAuthor,
 	LibraryBook,
+	LibraryBookPage,
+	LibraryBookQuery,
+	LibrarySeries,
 	NewAuthor,
 } from "@/bindings";
 
@@ -20,7 +23,15 @@ export interface FileType {
 export interface Library {
 	createAuthors(newAuthors: NewAuthor[]): Promise<LibraryAuthor[]>;
 	listBooks(): Promise<LibraryBook[]>;
+	/**
+	 * One page of a filtered, sorted book query (the cover grid's data
+	 * source). `query.text = null` matches all books; `total` counts the
+	 * filtered set ignoring paging.
+	 */
+	queryBooks(query: LibraryBookQuery): Promise<LibraryBookPage>;
 	listAuthors(): Promise<LibraryAuthor[]>;
+	/** Every series with its book count; ids feed `LibraryBookQuery.series_id`. */
+	listSeries(): Promise<LibrarySeries[]>;
 	sendToDevice(
 		book: LibraryBook,
 		deviceOptions: {

--- a/src/lib/services/library/_internal/adapters/calibre.ts
+++ b/src/lib/services/library/_internal/adapters/calibre.ts
@@ -3,6 +3,7 @@ import {
 	type ImportableBookMetadata,
 	type ImportableFile,
 	type LibraryBook,
+	type LibraryBookQuery,
 	type NewAuthor,
 	type RemoteFile,
 } from "@/bindings";
@@ -71,8 +72,37 @@ const genLocalCalibreClient = async (
 
 			return books;
 		},
+		queryBooks: async (query: LibraryBookQuery) => {
+			const results = await commands.clbQueryBooks(query);
+			if (results.status === "error") {
+				throw new Error(results.error);
+			}
+
+			for (const book of results.data.items) {
+				bookCoverCache.set(book.id.toString(), {
+					localPath: book.cover_image?.local_path ?? "",
+					url: book.cover_image?.url ?? "",
+				});
+				const primaryFile = book.file_list[0];
+				if (primaryFile !== undefined && "Local" in primaryFile) {
+					bookFilePath.set(book.id.toString(), {
+						localPath: primaryFile.Local.path,
+						url: undefined,
+					});
+				}
+			}
+
+			return results.data;
+		},
 		listAuthors: async () => {
 			const results = await commands.clbQueryListAllAuthors();
+			if (results.status === "error") {
+				throw new Error(results.error);
+			}
+			return results.data;
+		},
+		listSeries: async () => {
+			const results = await commands.clbQueryListSeries();
 			if (results.status === "error") {
 				throw new Error(results.error);
 			}
@@ -186,7 +216,13 @@ const genRemoteCalibreClient = async (
 
 			return res;
 		},
+		queryBooks() {
+			throw new Error("Not implemented");
+		},
 		listAuthors() {
+			throw new Error("Not implemented");
+		},
+		listSeries() {
 			throw new Error("Not implemented");
 		},
 		sendToDevice: () => {

--- a/src/routes/books.$bookId.tsx
+++ b/src/routes/books.$bookId.tsx
@@ -5,8 +5,8 @@ import { BookPage } from "@/components/pages/EditBook";
 import { Spinner } from "@/components/ui";
 import {
 	LibraryState,
+	useAllBooks,
 	useAuthors,
-	useBooks,
 	useLibraryActions,
 	useLibraryState,
 } from "@/stores/library/store";
@@ -23,8 +23,11 @@ const EditBookRoute = () => {
 	const state = useLibraryState();
 	const actions = useLibraryActions();
 
-	// Get data from store - no local state needed!
-	const books = useBooks();
+	// Whole-library list (lazy): the tag autocomplete needs the full tag
+	// vocabulary and there is no fetch-one-book or list-tags command, so
+	// this route stays on clb_query_list_all_books (one fetch on entry, off
+	// the hot path). See LibraryActions.loadBooks.
+	const { books, loading: loadingBooks } = useAllBooks();
 	const allAuthorList = useAuthors();
 	const allTagList = useMemo(
 		() =>
@@ -88,11 +91,15 @@ const EditBookRoute = () => {
 
 	const onReloadBooks = useCallback(async () => {
 		if (actions) {
+			// Drop stale paged-grid pages too, then refresh this route's list.
+			actions.invalidateBooks();
 			await actions.loadBooks();
 		}
 	}, [actions]);
 
-	if (state !== LibraryState.ready) {
+	// Spinner only for the initial fetch; refetches after edits keep the
+	// (stale-for-a-moment) form on screen instead of flashing.
+	if (state !== LibraryState.ready || (loadingBooks && books.length === 0)) {
 		return (
 			<div style={centeredFill}>
 				<Spinner size={18} />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,27 +2,26 @@ import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { Books } from "@/components/pages/Books";
 
 interface BookSearch {
-	search_for_author?: string;
-	search_for_series?: string;
+	/** Only books by this author (LibraryAuthor id). */
+	author_id?: string;
+	/** Only books in this series (LibrarySeries id). */
+	series_id?: number;
 }
 
 export const Route = createFileRoute("/")({
 	component: Index,
 	validateSearch: (search: Record<string, unknown>): BookSearch => {
 		// validate and parse the search params into a typed state
+		const seriesId = Number(search.series_id);
 		return {
-			search_for_author: (search.search_for_author as string) ?? undefined,
-			search_for_series: (search.search_for_series as string) ?? undefined,
+			author_id:
+				typeof search.author_id === "string" ? search.author_id : undefined,
+			series_id: Number.isInteger(seriesId) ? seriesId : undefined,
 		};
 	},
 });
 
 function Index() {
-	const { search_for_author, search_for_series } = useSearch({ from: "/" });
-	return (
-		<Books
-			search_for_author={search_for_author}
-			search_for_series={search_for_series}
-		/>
-	);
+	const { author_id, series_id } = useSearch({ from: "/" });
+	return <Books author_id={author_id} series_id={series_id} />;
 }

--- a/src/stores/library/store.ts
+++ b/src/stores/library/store.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { create } from "zustand";
 
 import type {
@@ -6,9 +7,24 @@ import type {
 	ImportableBookMetadata,
 	LibraryAuthor,
 	LibraryBook,
+	LibrarySeries,
 	NewAuthor,
 } from "@/bindings";
 import { commands } from "@/bindings";
+import {
+	ALL_BOOKS_FILTER,
+	applyBookPage,
+	BOOK_PAGE_SIZE,
+	type BookGridFilter,
+	cacheForKey,
+	compareBySeriesIndex,
+	emptyBookCache,
+	invalidateBookCache,
+	type PagedBookCache,
+	pagesCoveringRange,
+	serializeBookFilter,
+	toBookQuery,
+} from "@/lib/book-page-cache";
 import { sortAuthors } from "@/lib/domain/author";
 import type { Library, Options } from "@/lib/services/library";
 import { initClient } from "@/lib/services/library";
@@ -22,10 +38,43 @@ export enum LibraryState {
 
 interface LibraryActions {
 	// Core actions
+	/**
+	 * Loads the ENTIRE library into `books` via clb_query_list_all_books.
+	 *
+	 * Kept (and loaded lazily, see `useAllBooks`) for the consumers that
+	 * genuinely need whole-library data and have no targeted query:
+	 * - the Authors page: per-author book counts and the "authors without
+	 *   books" filter need every book↔author link;
+	 * - the book detail route: the tag autocomplete needs the full tag
+	 *   vocabulary (and there is no fetch-one-book command).
+	 * The cover grid does NOT use this; it pages via `ensureBookRange`.
+	 */
 	loadBooks: () => Promise<void>;
 	loadAuthors: () => Promise<void>;
+	loadSeries: () => Promise<void>;
 	initialize: (libraryPath: string) => Promise<void>;
 	reset: () => void;
+
+	// Paged book grid
+	/**
+	 * Points the paged cache at a new filter combination. A changed key swaps
+	 * in an empty cache (next generation); pages are then fetched on demand
+	 * by `ensureBookRange`.
+	 */
+	setBookFilter: (filter: BookGridFilter) => void;
+	/**
+	 * Fetches whichever pages covering the inclusive item-index range
+	 * [start, end] are missing from the current cache. Overlapping calls
+	 * de-dupe in flight; results only land while their cache key and
+	 * generation are still current.
+	 */
+	ensureBookRange: (start: number, end: number) => Promise<void>;
+	/**
+	 * After a mutation: drops all cached pages (visible ones refetch lazily),
+	 * marks the full list stale, and refreshes the series list and the
+	 * unfiltered library total.
+	 */
+	invalidateBooks: () => void;
 
 	// Library management
 	createLibrary: (libraryRoot: string) => Promise<void>;
@@ -58,15 +107,30 @@ interface LibraryStoreState {
 	libraryState: LibraryState;
 	libraryError: Error | null;
 
-	// Books state
+	// Whole-library book list (lazy; see LibraryActions.loadBooks)
 	books: LibraryBook[];
 	booksLoading: boolean;
 	booksError: string | null;
+	/** Bumped by invalidateBooks; the full list is fresh iff it matches. */
+	allBooksGeneration: number;
+	allBooksLoadedGeneration: number;
+
+	// Paged book grid state
+	bookFilter: BookGridFilter;
+	bookCache: PagedBookCache;
+	bookPagesError: string | null;
+	/** Unfiltered library size (for "N of M books"); null until known. */
+	libraryTotal: number | null;
 
 	// Authors state
 	authors: LibraryAuthor[];
 	authorsLoading: boolean;
 	authorsError: string | null;
+
+	// Series state
+	series: LibrarySeries[];
+	seriesLoading: boolean;
+	seriesError: string | null;
 
 	// Stable actions object containing ALL actions
 	actions: LibraryActions;
@@ -79,9 +143,18 @@ const initialState = {
 	books: [],
 	booksLoading: false,
 	booksError: null,
+	allBooksGeneration: 0,
+	allBooksLoadedGeneration: -1,
+	bookFilter: ALL_BOOKS_FILTER,
+	bookCache: emptyBookCache(serializeBookFilter(ALL_BOOKS_FILTER), 0),
+	bookPagesError: null,
+	libraryTotal: null,
 	authors: [],
 	authorsLoading: false,
 	authorsError: null,
+	series: [],
+	seriesLoading: false,
+	seriesError: null,
 };
 
 const localLibraryFromPath = (path: string): Options => ({
@@ -90,177 +163,351 @@ const localLibraryFromPath = (path: string): Options => ({
 	connectionType: "local",
 });
 
-export const useLibraryStore = create<LibraryStoreState>((set, get) => ({
-	...initialState,
+// In-flight de-dupe (module scope: promises are not store state).
+const inFlightBookPages = new Map<string, Promise<void>>();
+let inFlightAllBooks: Promise<void> | null = null;
 
-	// Stable actions object - ALL actions go here, created once and never change
-	actions: {
-		loadBooks: async () => {
-			const { library } = get();
-			if (!library) return;
+export const useLibraryStore = create<LibraryStoreState>((set, get) => {
+	const fetchBookPage = (
+		library: Library,
+		filter: BookGridFilter,
+		key: string,
+		generation: number,
+		pageIndex: number,
+	): Promise<void> => {
+		const flightKey = `${generation}:${pageIndex}:${key}`;
+		const existing = inFlightBookPages.get(flightKey);
+		if (existing) return existing;
 
-			set({ booksLoading: true, booksError: null });
+		const flight = (async () => {
 			try {
-				const books = await library.listBooks();
-				set({ books, booksLoading: false });
+				const page = await library.queryBooks(toBookQuery(filter, pageIndex));
+				// A series reads in series order; the backend only sorts by
+				// title/author, so the (single, unbounded) series page is
+				// sorted by series_index here.
+				const items =
+					filter.seriesId !== null
+						? [...page.items].sort(compareBySeriesIndex)
+						: page.items;
+				set((state) => ({
+					bookCache: applyBookPage(state.bookCache, {
+						key,
+						generation,
+						pageIndex,
+						items,
+						total: page.total,
+					}),
+					bookPagesError: null,
+				}));
 			} catch (error) {
 				set({
-					booksError:
+					bookPagesError:
 						error instanceof Error ? error.message : "Failed to load books",
-					booksLoading: false,
 				});
+			} finally {
+				inFlightBookPages.delete(flightKey);
 			}
+		})();
+		inFlightBookPages.set(flightKey, flight);
+		return flight;
+	};
+
+	const refreshLibraryTotal = async (): Promise<void> => {
+		const { library } = get();
+		if (!library) return;
+		try {
+			// limit 0: count-only query (items stay empty, total ignores paging).
+			const page = await library.queryBooks({
+				...toBookQuery(ALL_BOOKS_FILTER, 0),
+				limit: 0,
+			});
+			set({ libraryTotal: page.total });
+		} catch (error) {
+			console.error("Failed to load library total:", error);
+		}
+	};
+
+	return {
+		...initialState,
+
+		// Stable actions object - ALL actions go here, created once and never change
+		actions: {
+			loadBooks: async () => {
+				const { library } = get();
+				if (!library) return;
+				if (inFlightAllBooks) return inFlightAllBooks;
+
+				const generation = get().allBooksGeneration;
+				set({ booksLoading: true, booksError: null });
+				inFlightAllBooks = (async () => {
+					try {
+						const books = await library.listBooks();
+						set({
+							books,
+							booksLoading: false,
+							allBooksLoadedGeneration: generation,
+						});
+					} catch (error) {
+						set({
+							booksError:
+								error instanceof Error ? error.message : "Failed to load books",
+							booksLoading: false,
+						});
+					} finally {
+						inFlightAllBooks = null;
+					}
+				})();
+				return inFlightAllBooks;
+			},
+
+			loadAuthors: async () => {
+				const { library } = get();
+				if (!library) return;
+
+				set({ authorsLoading: true, authorsError: null });
+				try {
+					const authors = await library.listAuthors();
+					set({ authors: authors.sort(sortAuthors), authorsLoading: false });
+				} catch (error) {
+					set({
+						authorsError:
+							error instanceof Error ? error.message : "Failed to load authors",
+						authorsLoading: false,
+					});
+				}
+			},
+
+			loadSeries: async () => {
+				const { library } = get();
+				if (!library) return;
+
+				set({ seriesLoading: true, seriesError: null });
+				try {
+					const series = await library.listSeries();
+					set({ series, seriesLoading: false });
+				} catch (error) {
+					set({
+						seriesError:
+							error instanceof Error ? error.message : "Failed to load series",
+						seriesLoading: false,
+					});
+				}
+			},
+
+			setBookFilter: (filter: BookGridFilter) => {
+				const key = serializeBookFilter(filter);
+				const cache = cacheForKey(get().bookCache, key);
+				set({ bookFilter: filter, bookCache: cache });
+			},
+
+			ensureBookRange: async (start: number, end: number) => {
+				const { library, bookFilter, bookCache } = get();
+				if (!library) return;
+				// Only serve the current key; a filter change mid-scroll means
+				// the caller's range belongs to a retired cache.
+				if (bookCache.key !== serializeBookFilter(bookFilter)) return;
+
+				// A series is fetched whole as page 0 (see toBookQuery).
+				const wantedPages =
+					bookFilter.seriesId !== null
+						? [0]
+						: pagesCoveringRange(start, end, BOOK_PAGE_SIZE, bookCache.total);
+				const missing = wantedPages.filter(
+					(pageIndex) => !bookCache.pages.has(pageIndex),
+				);
+				if (missing.length === 0) return;
+
+				await Promise.all(
+					missing.map((pageIndex) =>
+						fetchBookPage(
+							library,
+							bookFilter,
+							bookCache.key,
+							bookCache.generation,
+							pageIndex,
+						),
+					),
+				);
+			},
+
+			invalidateBooks: () => {
+				set((state) => ({
+					bookCache: invalidateBookCache(state.bookCache),
+					allBooksGeneration: state.allBooksGeneration + 1,
+				}));
+				// Mutations can rename/create series and change the library
+				// size; refresh both in the background.
+				void get().actions.loadSeries();
+				void refreshLibraryTotal();
+			},
+
+			initialize: async (libraryPath: string) => {
+				const actions = get().actions;
+
+				// Retire any cached data from a previously open library. The
+				// paged cache keeps its key but moves to a new generation so
+				// in-flight fetches against the old library cannot land.
+				set((state) => ({
+					libraryState: LibraryState.initializing,
+					libraryError: null,
+					books: [],
+					allBooksLoadedGeneration: -1,
+					bookCache: emptyBookCache(
+						state.bookCache.key,
+						state.bookCache.generation + 1,
+					),
+					libraryTotal: null,
+				}));
+
+				try {
+					const library = await initClient(localLibraryFromPath(libraryPath));
+					set({ library });
+
+					// The grid pages books in on demand (ensureBookRange); only
+					// the cheap whole-library facts load eagerly.
+					await Promise.all([
+						actions.loadAuthors(),
+						actions.loadSeries(),
+						refreshLibraryTotal(),
+					]);
+
+					set({ libraryState: LibraryState.ready });
+				} catch (error) {
+					console.error("Failed to initialize library:", error);
+					set({
+						libraryState: LibraryState.error,
+						libraryError:
+							error instanceof Error ? error : new Error(String(error)),
+					});
+				}
+			},
+
+			reset: () => {
+				set((state) => ({
+					...initialState,
+					// Keep the generation monotonic so fetches started before the
+					// reset cannot land in the fresh cache.
+					bookCache: emptyBookCache(
+						initialState.bookCache.key,
+						state.bookCache.generation + 1,
+					),
+					actions: state.actions,
+				}));
+			},
+
+			createLibrary: async (libraryRoot: string) => {
+				const create = await commands.clbCmdCreateLibrary(libraryRoot);
+				if (create.status === "error") {
+					console.error("Failed to create library", create.error);
+					return;
+				}
+			},
+
+			listValidFileTypes: async () => {
+				const { library } = get();
+				if (!library) return [];
+				const types = await library.listValidFileTypes();
+				return types.map((type) => type.extension);
+			},
+
+			getImportableBookMetadata: async (filePath: string) => {
+				const { library } = get();
+				if (!library) return;
+
+				const importableFile = await library.checkFileImportable(filePath);
+				if (!importableFile) {
+					console.error(`File ${filePath} not importable`);
+					return;
+				}
+				const metadata =
+					await library.getImportableFileMetadata(importableFile);
+				if (!metadata) {
+					console.error(`Failed to get metadata for file at ${filePath}`);
+					return;
+				}
+
+				return metadata;
+			},
+
+			commitAddBook: async (metadata: ImportableBookMetadata) => {
+				const { library } = get();
+				if (!library) return;
+
+				const bookId = await library.addImportableFileByMetadata(metadata);
+				return bookId;
+			},
+			updateBook: async (
+				bookId: string,
+				updates: BookUpdate,
+			): Promise<void> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				await library.updateBook(bookId, updates);
+				get().actions.invalidateBooks();
+			},
+
+			updateAuthor: async (
+				authorId: string,
+				updates: AuthorUpdate,
+			): Promise<void> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				await library.updateAuthor(authorId, updates);
+				await get().actions.loadAuthors();
+				// Cached pages render the old author name (and sort position).
+				get().actions.invalidateBooks();
+			},
+
+			createAuthors: async (newAuthors: NewAuthor[]): Promise<void> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				await library.createAuthors(newAuthors);
+				await get().actions.loadAuthors();
+			},
+
+			deleteAuthor: async (authorId: string): Promise<void> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				await library.deleteAuthor(authorId);
+				await get().actions.loadAuthors();
+			},
+
+			deleteBookIdentifier: async (
+				bookId: string,
+				identifierId: number,
+			): Promise<void> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				await library.deleteBookIdentifier(bookId, identifierId);
+				get().actions.invalidateBooks();
+			},
+
+			upsertBookIdentifier: async (
+				bookId: string,
+				identifierId: number | null,
+				label: string,
+				value: string,
+			): Promise<void> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				await library.upsertBookIdentifier(bookId, identifierId, label, value);
+				get().actions.invalidateBooks();
+			},
+
+			addBook: async (
+				metadata: ImportableBookMetadata,
+			): Promise<string | undefined> => {
+				const { library } = get();
+				if (!library) throw new Error("Library not initialized");
+				const bookId = await library.addImportableFileByMetadata(metadata);
+				if (bookId) {
+					get().actions.invalidateBooks();
+				}
+				return bookId;
+			},
 		},
-
-		loadAuthors: async () => {
-			const { library } = get();
-			if (!library) return;
-
-			set({ authorsLoading: true, authorsError: null });
-			try {
-				const authors = await library.listAuthors();
-				set({ authors: authors.sort(sortAuthors), authorsLoading: false });
-			} catch (error) {
-				set({
-					authorsError:
-						error instanceof Error ? error.message : "Failed to load authors",
-					authorsLoading: false,
-				});
-			}
-		},
-
-		initialize: async (libraryPath: string) => {
-			const actions = get().actions;
-
-			set({ libraryState: LibraryState.initializing, libraryError: null });
-
-			try {
-				const library = await initClient(localLibraryFromPath(libraryPath));
-				set({ library });
-
-				await Promise.all([actions.loadBooks(), actions.loadAuthors()]);
-
-				set({ libraryState: LibraryState.ready });
-			} catch (error) {
-				console.error("Failed to initialize library:", error);
-				set({
-					libraryState: LibraryState.error,
-					libraryError:
-						error instanceof Error ? error : new Error(String(error)),
-				});
-			}
-		},
-
-		reset: () => {
-			set({ ...initialState, actions: get().actions });
-		},
-
-		createLibrary: async (libraryRoot: string) => {
-			const create = await commands.clbCmdCreateLibrary(libraryRoot);
-			if (create.status === "error") {
-				console.error("Failed to create library", create.error);
-				return;
-			}
-		},
-
-		listValidFileTypes: async () => {
-			const { library } = get();
-			if (!library) return [];
-			const types = await library.listValidFileTypes();
-			return types.map((type) => type.extension);
-		},
-
-		getImportableBookMetadata: async (filePath: string) => {
-			const { library } = get();
-			if (!library) return;
-
-			const importableFile = await library.checkFileImportable(filePath);
-			if (!importableFile) {
-				console.error(`File ${filePath} not importable`);
-				return;
-			}
-			const metadata = await library.getImportableFileMetadata(importableFile);
-			if (!metadata) {
-				console.error(`Failed to get metadata for file at ${filePath}`);
-				return;
-			}
-
-			return metadata;
-		},
-
-		commitAddBook: async (metadata: ImportableBookMetadata) => {
-			const { library } = get();
-			if (!library) return;
-
-			const bookId = await library.addImportableFileByMetadata(metadata);
-			return bookId;
-		},
-		updateBook: async (bookId: string, updates: BookUpdate): Promise<void> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			await library.updateBook(bookId, updates);
-			await get().actions.loadBooks();
-		},
-
-		updateAuthor: async (
-			authorId: string,
-			updates: AuthorUpdate,
-		): Promise<void> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			await library.updateAuthor(authorId, updates);
-			await get().actions.loadAuthors();
-		},
-
-		createAuthors: async (newAuthors: NewAuthor[]): Promise<void> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			await library.createAuthors(newAuthors);
-			await get().actions.loadAuthors();
-		},
-
-		deleteAuthor: async (authorId: string): Promise<void> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			await library.deleteAuthor(authorId);
-			await get().actions.loadAuthors();
-		},
-
-		deleteBookIdentifier: async (
-			bookId: string,
-			identifierId: number,
-		): Promise<void> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			await library.deleteBookIdentifier(bookId, identifierId);
-			await get().actions.loadBooks();
-		},
-
-		upsertBookIdentifier: async (
-			bookId: string,
-			identifierId: number | null,
-			label: string,
-			value: string,
-		): Promise<void> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			await library.upsertBookIdentifier(bookId, identifierId, label, value);
-			await get().actions.loadBooks();
-		},
-
-		addBook: async (
-			metadata: ImportableBookMetadata,
-		): Promise<string | undefined> => {
-			const { library } = get();
-			if (!library) throw new Error("Library not initialized");
-			const bookId = await library.addImportableFileByMetadata(metadata);
-			if (bookId) {
-				await get().actions.loadBooks();
-			}
-			return bookId;
-		},
-	},
-}));
+	};
+});
 
 // Selectors for library state
 export const useLibraryState = () =>
@@ -272,11 +519,39 @@ export const useLibraryInitializing = () =>
 export const useLibraryError = () =>
 	useLibraryStore((state) => state.libraryError);
 
-// Selectors for books
-export const useBooks = () => useLibraryStore((state) => state.books);
-export const useBooksLoading = () =>
-	useLibraryStore((state) => state.booksLoading);
-export const useBooksError = () => useLibraryStore((state) => state.booksError);
+// Selectors for the paged book grid
+export const useBookCache = () => useLibraryStore((state) => state.bookCache);
+export const useBookPagesError = () =>
+	useLibraryStore((state) => state.bookPagesError);
+export const useLibraryTotal = () =>
+	useLibraryStore((state) => state.libraryTotal);
+
+/**
+ * The whole-library book list, loaded lazily on first use and reloaded
+ * after mutations mark it stale. Only for consumers that genuinely need
+ * every book (see LibraryActions.loadBooks); the cover grid pages instead.
+ */
+export const useAllBooks = (): { books: LibraryBook[]; loading: boolean } => {
+	const books = useLibraryStore((state) => state.books);
+	const loading = useLibraryStore((state) => state.booksLoading);
+	// Both generations (not a derived boolean) so the effect re-fires when a
+	// load lands but a newer invalidation already superseded it.
+	const generation = useLibraryStore((state) => state.allBooksGeneration);
+	const loadedGeneration = useLibraryStore(
+		(state) => state.allBooksLoadedGeneration,
+	);
+	const ready = useLibraryReady();
+	const actions = useLibraryActions();
+
+	const stale = loadedGeneration !== generation;
+	useEffect(() => {
+		if (ready && loadedGeneration !== generation) {
+			void actions.loadBooks();
+		}
+	}, [ready, generation, loadedGeneration, actions]);
+
+	return { books, loading: loading || (stale && books.length === 0) };
+};
 
 // Selectors for authors
 export const useAuthors = () => useLibraryStore((state) => state.authors);
@@ -284,6 +559,11 @@ export const useAuthorsLoading = () =>
 	useLibraryStore((state) => state.authorsLoading);
 export const useAuthorsError = () =>
 	useLibraryStore((state) => state.authorsError);
+
+// Selectors for series
+export const useSeriesList = () => useLibraryStore((state) => state.series);
+export const useSeriesLoading = () =>
+	useLibraryStore((state) => state.seriesLoading);
 
 // Selector for stable actions object
 export const useLibraryActions = () =>


### PR DESCRIPTION
## Cache design

The library store replaces the grid's full `books` array with a paged query cache (`src/lib/book-page-cache.ts`, pure and vitest-covered):

- **Key**: serialized `(text, author_id, series_id, hide_read, sort)` — the debounced filter combination. Sorting is part of the key because a page fetched under one order holds different indices under another.
- **Value**: `{ total, pages: sparse Map<pageIndex, LibraryBook[]>, generation }`. **Page size 100** (10–25 virtualized shelf rows ≈ several viewports per fetch, while staying a small IPC payload).
- **`ensureBookRange(start, end)`** maps the grid's visible+overscan index range to page indices and fetches only the missing ones via `clbQueryBooks` (`limit=100`, `offset=page*100`). Overlapping scroll callbacks de-dupe through an in-flight map keyed `generation:page:key`.
- **Generations**: results only land if their key *and* generation still match (`applyBookPage`). Mutations (`updateBook`, `addBook`, identifier edits, author rename, Hardcover cover set) call `invalidateBooks()` instead of refetching everything: pages drop, the generation bumps (cancelling in-flight results), the last total is kept so the grid holds its height, and the visible pages refetch lazily.
- `BookGrid` keeps its indexed-array interface: it gets a sparse `(LibraryBook | undefined)[]` of length `total`; `undefined` slots render a quiet cover-shaped placeholder cell (no card redesign). A new `onVisibleRangeChange` prop reports the rendered row window so pages stream in while scrolling.
- Keyboard nav is now positional: selection tracks the index, `scrollToIndex` brings the row in (which pages its books in), and the selection ring applies once the book arrives. Selection resets when the cache key changes.

## Filter/sort migration

| Previously (client-side in Books.tsx) | Now |
|---|---|
| `filterBooksByQuery` text match over title/author | `LibraryBookQuery.text` (SQL LIKE over title/author/series, wildcards escaped backend-side), debounced 200 ms before becoming a cache key; the text field stays instant |
| `hideRead` array filter | `LibraryBookQuery.hide_read` (SQL, so paging + totals stay correct) |
| `sortOrder` localeCompare sort (`nameAz/nameZa/authorAz/authorZa`) | `LibraryBookQuery.sort` (`TitleAsc/TitleDesc/AuthorAsc/AuthorDesc`, Calibre sort columns, stable id tiebreak) |
| `search_for_author` route param (author **name** poured into the text query) | `author_id` route param → `LibraryBookQuery.author_id`, shown as a removable search token (mirrors the series token) |
| `search_for_series` route param (series **name**, exact match client-side) | `series_id` route param → `LibraryBookQuery.series_id`. Series ids never crossed the IPC boundary before, so this adds one minimal backend command, `clb_query_list_series` (id, name, book_count). Book-detail series links resolve name→id through that list. A series filter fetches the whole series unpaged (`limit=null`) and sorts by `series_index` client-side, since the backend offers no series-index sort and series are small |
| Footer `X of Y books` from array lengths | `total` from the current cache + a one-time `limit=0` count query for the unfiltered library size |

## Consumer audit (`useBooks` / `clbQueryListAllBooks`)

| Consumer | Outcome |
|---|---|
| Books.tsx (cover grid) | **Migrated** to the paged cache; `filterBooksByQuery` and the client sorts deleted |
| Series page | **Migrated** to `clb_query_list_series` (sorted names + counts straight from SQL); `deriveSeriesSummaries` deleted |
| Smart shelves (CDL-9) | **No list-all needed**: shelves are filter presets (query/sort/hideRead) applied to the library view, which now flows through the backend query like any other filter |
| Authors page | **Kept `clb_query_list_all_books`**, now lazy (`useAllBooks`, loaded on first visit, re-fetched only after mutations): per-author book counts and the "authors without books" filter need every book↔author link and no targeted count query exists — N-per-author count queries would be contortion |
| Book detail route (`books.$bookId`) | **Kept `clb_query_list_all_books`**, lazy: the tag autocomplete needs the library-wide tag vocabulary and there is no fetch-one-book or list-tags command; a single-book query alone would not remove the dependency. One fetch on route entry, off the hot path |

Both keeps are documented in code comments (`LibraryActions.loadBooks`).

## Backend addition (minimal)

`clb_query_list_series` → `Vec<LibrarySeries { id, name, book_count }>`, backed by `Library::list_series()` (one GROUP BY over `books_series_link`). It is the only way to map the frontend's series names to the ids `LibraryBookQuery.series_id` filters on. `bindings.ts` hand-edited in exact specta style.

## Tests

- `src/lib/book-page-cache.test.ts` (25 tests): key serialization, sort/query mapping, range→pages math (clamping, unknown totals), sparse flattening (holes, oversized series page, shrunk totals), generation/key invalidation semantics, series-index comparator.
- `crates/libcalibre/tests/query_test.rs`: `list_series` counts, name sorting, and id agreement with `BookQuery::series_id`.

## Gates

`cargo fmt --all` ✓ · `cargo clippy --workspace` ✓ · `cargo test --workspace` ✓ (all suites green) · `bunx tsc --noEmit` ✓ · `bunx biome lint src/` ✓ (2 pre-existing warnings, also on main) · `bunx vitest run` ✓ (168 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)