### PR TITLE
Empty states that teach for Books and Authors

### DIFF
--- a/src/components/molecules/EmptyState.module.css
+++ b/src/components/molecules/EmptyState.module.css
@@ -1,0 +1,42 @@
+.root {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	min-height: 240px;
+	padding: 24px;
+}
+
+.inner {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	text-align: center;
+	gap: 8px;
+	max-width: 420px;
+}
+
+.title {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+	line-height: 1.3;
+	color: var(--ctd-ink);
+}
+
+.description {
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.45;
+	color: var(--ctd-ink-soft);
+}
+
+.actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	/* A little breathing room below the copy before the action row. */
+	margin-top: 8px;
+}

--- a/src/components/molecules/EmptyState.tsx
+++ b/src/components/molecules/EmptyState.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import { useAddBook } from "@/components/organisms/AddBook";
+import { Button } from "@/components/ui";
+import { useOpenSettings } from "@/lib/hooks/use-open-settings";
+import styles from "./EmptyState.module.css";
+
+export interface EmptyStateProps {
+	/** Short heading naming what's empty or unmatched. */
+	title: string;
+	/** Optional soft explanatory line under the title. */
+	description?: ReactNode;
+	/** Action buttons, rendered in a centered row beneath the copy. */
+	children?: ReactNode;
+}
+
+/**
+ * Quiet, illustration-free placeholder for empty grids/lists and zero-result
+ * filters (DESIGN.md: neutral chrome, no empty-state art). Fills the height of
+ * its scroll container and centers a heading, optional description, and an
+ * action row.
+ */
+export const EmptyState = ({
+	title,
+	description,
+	children,
+}: EmptyStateProps) => {
+	return (
+		<div className={styles.root}>
+			<div className={styles.inner}>
+				<h2 className={styles.title}>{title}</h2>
+				{description !== undefined && (
+					<p className={styles.description}>{description}</p>
+				)}
+				{children !== undefined && (
+					<div className={styles.actions}>{children}</div>
+				)}
+			</div>
+		</div>
+	);
+};
+
+/**
+ * First-run / empty-library teaching state. Names the two ways to populate the
+ * library: import a book, or point Citadel at an existing Calibre library.
+ * Shared by the Books and Authors pages.
+ */
+export const EmptyLibrary = () => {
+	const { startAddBook, canAddBook } = useAddBook();
+	const openSettings = useOpenSettings();
+
+	return (
+		<EmptyState
+			title="Your library is empty"
+			description={
+				canAddBook
+					? "Add a book to this library, or switch to an existing Calibre library."
+					: "Switch to an existing Calibre library to get started."
+			}
+		>
+			{canAddBook && (
+				<Button variant="primary" onClick={startAddBook}>
+					Add Book…
+				</Button>
+			)}
+			<Button variant="default" onClick={openSettings}>
+				Switch library…
+			</Button>
+		</EmptyState>
+	);
+};

--- a/src/components/organisms/AddBook.tsx
+++ b/src/components/organisms/AddBook.tsx
@@ -1,6 +1,15 @@
 import { isTauri } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import type { ImportableBookMetadata, NewAuthor } from "@/bindings";
 import { commands } from "@/bindings";
 import {
@@ -20,14 +29,27 @@ import {
 	useLibraryState,
 } from "@/stores/library/store";
 
-export const AddBookButton = () => {
+interface AddBookContextValue {
+	/** Opens the native file picker and walks the import flow. */
+	startAddBook: () => void;
+	/** True when the library is ready and the platform can pick local files. */
+	canAddBook: boolean;
+}
+
+const AddBookContext = createContext<AddBookContextValue | null>(null);
+
+/**
+ * Owns the add-book import flow (file picker → metadata → confirm sheet) and
+ * exposes it via {@link useAddBook} so any control — the toolbar button, an
+ * empty-state prompt — can start it without duplicating the flow.
+ */
+export const AddBookProvider = ({ children }: { children: ReactNode }) => {
 	const state = useLibraryState();
 	const actions = useLibraryActions();
 	const authors = useAuthors();
 	const platform = usePlatform();
 
 	const [metadata, setMetadata] = useState<ImportableBookMetadata | null>();
-	const addBookButtonRef = useRef<HTMLButtonElement>(null);
 	// Incremented per picked file so AddBookForm (and its Hardcover lookup
 	// state) remounts fresh for each import.
 	const [importSession, setImportSession] = useState(0);
@@ -36,6 +58,10 @@ export const AddBookButton = () => {
 	// reuses the created book instead of creating a duplicate.
 	const createdBookIdRef = useRef<string | null>(null);
 	const [isModalOpen, setIsModalOpen] = useState(false);
+	// The control that opened the flow, so focus can return there on close. The
+	// trigger may unmount before then (e.g. an empty-state button disappears
+	// once the first book is added), so the restore is best-effort.
+	const triggerRef = useRef<HTMLElement | null>(null);
 	const openModal = useCallback(() => setIsModalOpen(true), []);
 	const closeModal = useCallback(() => setIsModalOpen(false), []);
 
@@ -60,8 +86,16 @@ export const AddBookButton = () => {
 		[actions],
 	);
 
-	const selectAndEditBookFile = useCallback(() => {
+	const canAddBook =
+		state === LibraryState.ready && platform.capabilities.canPickLocalFiles;
+
+	const startAddBook = useCallback(() => {
 		if (state !== LibraryState.ready) return;
+
+		triggerRef.current =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
 
 		void (async () => {
 			try {
@@ -91,12 +125,12 @@ export const AddBookButton = () => {
 	useEffect(() => {
 		if (!isTauri()) return;
 		const unlisten = listen("menu://add-book", () => {
-			selectAndEditBookFile();
+			startAddBook();
 		});
 		return () => {
 			void unlisten.then((dispose) => dispose());
 		};
-	}, [selectAndEditBookFile]);
+	}, [startAddBook]);
 
 	const addBookByMetadataWithEffects = async (form: AddBookForm) => {
 		if (!metadata || state !== LibraryState.ready) return;
@@ -146,15 +180,13 @@ export const AddBookButton = () => {
 		}
 	};
 
-	if (
-		state !== LibraryState.ready ||
-		!platform.capabilities.canPickLocalFiles
-	) {
-		return null;
-	}
+	const contextValue = useMemo<AddBookContextValue>(
+		() => ({ startAddBook, canAddBook }),
+		[startAddBook, canAddBook],
+	);
 
 	return (
-		<>
+		<AddBookContext.Provider value={contextValue}>
 			{metadata && (
 				// Compact sheet anchored under the toolbar (macOS document-sheet
 				// feel): light dim, the library stays visible behind it.
@@ -167,9 +199,12 @@ export const AddBookButton = () => {
 					width={480}
 					onCloseAutoFocus={(event) => {
 						// The sheet opens from a file-picker flow, not a Dialog.Trigger,
-						// so return focus to the Add Book button ourselves.
-						event.preventDefault();
-						addBookButtonRef.current?.focus();
+						// so return focus to whatever opened it ourselves.
+						const trigger = triggerRef.current;
+						if (trigger?.isConnected) {
+							event.preventDefault();
+							trigger.focus();
+						}
 					}}
 				>
 					<AddBookForm
@@ -191,29 +226,48 @@ export const AddBookButton = () => {
 					/>
 				</Sheet>
 			)}
-			<Button
-				ref={addBookButtonRef}
-				variant="default"
-				size="sm"
-				aria-label="Add Book"
-				onClick={selectAndEditBookFile}
+			{children}
+		</AddBookContext.Provider>
+	);
+};
+
+export const useAddBook = (): AddBookContextValue => {
+	const context = useContext(AddBookContext);
+	if (context === null) {
+		throw new Error("useAddBook must be used within an AddBookProvider");
+	}
+	return context;
+};
+
+export const AddBookButton = () => {
+	const { startAddBook, canAddBook } = useAddBook();
+
+	if (!canAddBook) {
+		return null;
+	}
+
+	return (
+		<Button
+			variant="default"
+			size="sm"
+			aria-label="Add Book"
+			onClick={startAddBook}
+		>
+			<svg
+				width="13"
+				height="13"
+				viewBox="0 0 15 15"
+				fill="none"
+				aria-hidden="true"
 			>
-				<svg
-					width="13"
-					height="13"
-					viewBox="0 0 15 15"
-					fill="none"
-					aria-hidden="true"
-				>
-					<path
-						d="M7.5 2v11M2 7.5h11"
-						stroke="currentColor"
-						strokeWidth="1.4"
-						strokeLinecap="round"
-					/>
-				</svg>
-				Add Book…
-			</Button>
-		</>
+				<path
+					d="M7.5 2v11M2 7.5h11"
+					stroke="currentColor"
+					strokeWidth="1.4"
+					strokeLinecap="round"
+				/>
+			</svg>
+			Add Book…
+		</Button>
 	);
 };

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -1,14 +1,13 @@
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
-import { isTauri } from "@tauri-apps/api/core";
 import clsx from "clsx";
-import { useCallback, useEffect, useState } from "react";
-import { commands } from "@/bindings";
+import { useEffect, useState } from "react";
 import { F7Gear } from "@/components/icons/F7Gear";
 import { F7Pencil } from "@/components/icons/F7Pencil";
 import { F7Trash } from "@/components/icons/F7Trash";
 import { AlertDialog, IconButton, TextInput } from "@/components/ui";
 import { safeAsyncEventHandler } from "@/lib/async";
 import { useAppUpdates } from "@/lib/hooks/use-app-updates";
+import { useOpenSettings } from "@/lib/hooks/use-open-settings";
 import type { SmartShelf } from "@/lib/platform/settings/types";
 import { LibraryState, useLibraryState } from "@/stores/library/store";
 import { useLibraryView } from "@/stores/library-view/store";
@@ -19,17 +18,7 @@ import styles from "./Sidebar.module.css";
 export const Sidebar = () => {
 	const state = useLibraryState();
 	const { location } = useRouterState();
-	const navigate = useNavigate();
-
-	// Settings live in their own window; the Rust command owns the window
-	// options and focuses the existing window if one is already open.
-	const openSettings = useCallback(() => {
-		if (isTauri()) {
-			void commands.clbCmdOpenSettings();
-		} else {
-			void navigate({ to: "/settings" });
-		}
-	}, [navigate]);
+	const openSettings = useOpenSettings();
 
 	const isUpdatePromptOpen = useAppUpdates((s) => s.isUpdatePromptOpen);
 	const isInstallingUpdate = useAppUpdates((s) => s.isInstallingUpdate);

--- a/src/components/pages/Authors.tsx
+++ b/src/components/pages/Authors.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/stores/library/store";
 import { F7Pencil } from "../icons/F7Pencil";
 import { F7Trash } from "../icons/F7Trash";
+import { EmptyLibrary, EmptyState } from "../molecules/EmptyState";
 import styles from "./Authors.module.css";
 
 /**
@@ -131,6 +132,19 @@ export const Authors = () => {
 		return null;
 	}
 
+	// An empty library has no authors (they're created only when books are
+	// imported), so teach the two ways to populate it instead of an empty list.
+	if (authors.length === 0) {
+		return (
+			<div className={styles.page}>
+				<EmptyLibrary />
+			</div>
+		);
+	}
+
+	const searchTerm = filters.searchTerm.trim();
+	const noMatches = filteredAuthors.length === 0;
+
 	return (
 		<div className={styles.page}>
 			{authorToEdit && (
@@ -168,30 +182,51 @@ export const Authors = () => {
 				/>
 			</div>
 
-			<div className={styles.headerRow} style={AUTHOR_GRID}>
-				<span className={styles.columnLabel}>Name</span>
-				<span className={clsx(styles.columnLabel, styles.visibleFromMd)}>
-					Sort name
-				</span>
-				<span className={clsx(styles.columnLabel, styles.columnLabelRight)}>
-					Books
-				</span>
-				<span />
-			</div>
+			{noMatches ? (
+				searchTerm.length > 0 ? (
+					<EmptyState title={`No authors match “${searchTerm}”`}>
+						<Button variant="default" onClick={() => setSearchTerm("")}>
+							Clear search
+						</Button>
+					</EmptyState>
+				) : (
+					<EmptyState title="No authors match these filters.">
+						<Button
+							variant="default"
+							onClick={() => setShowOnlyAuthorsWithoutBooks(false)}
+						>
+							Show all authors
+						</Button>
+					</EmptyState>
+				)
+			) : (
+				<>
+					<div className={styles.headerRow} style={AUTHOR_GRID}>
+						<span className={styles.columnLabel}>Name</span>
+						<span className={clsx(styles.columnLabel, styles.visibleFromMd)}>
+							Sort name
+						</span>
+						<span className={clsx(styles.columnLabel, styles.columnLabelRight)}>
+							Books
+						</span>
+						<span />
+					</div>
 
-			<AuthorRows
-				authors={filteredAuthors}
-				onEditAuthor={onOpenEditAuthorSheet}
-				onDeleteAuthor={onOpenDeleteAuthorDialog}
-			/>
+					<AuthorRows
+						authors={filteredAuthors}
+						onEditAuthor={onOpenEditAuthorSheet}
+						onDeleteAuthor={onOpenDeleteAuthorDialog}
+					/>
 
-			<div className={styles.footer}>
-				<span className={styles.footerText}>
-					{filteredAuthors.length === authors.length
-						? `${authors.length} authors`
-						: `${filteredAuthors.length} of ${authors.length} authors`}
-				</span>
-			</div>
+					<div className={styles.footer}>
+						<span className={styles.footerText}>
+							{filteredAuthors.length === authors.length
+								? `${authors.length} authors`
+								: `${filteredAuthors.length} of ${authors.length} authors`}
+						</span>
+					</div>
+				</>
+			)}
 		</div>
 	);
 };

--- a/src/components/pages/Books.module.css
+++ b/src/components/pages/Books.module.css
@@ -53,22 +53,6 @@
 	transition: opacity 150ms ease-out;
 }
 
-/* Zero-result filters (e.g. a shelf whose query no longer matches). */
-.emptyState {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 12px;
-	height: 100%;
-	min-height: 240px;
-}
-
-.emptyText {
-	font-size: 14px;
-	color: var(--ctd-ink-soft);
-}
-
 /* Save-as-shelf sheet body. */
 .shelfForm {
 	display: flex;

--- a/src/components/pages/Books.tsx
+++ b/src/components/pages/Books.tsx
@@ -51,6 +51,7 @@ import { F7Bookmark } from "../icons/F7Bookmark";
 import { F7Pencil } from "../icons/F7Pencil";
 import { TablerCopy } from "../icons/TablerCopy";
 import { BookGrid, type ScrollToBookIndex } from "../molecules/BookGrid";
+import { EmptyLibrary, EmptyState } from "../molecules/EmptyState";
 import styles from "./Books.module.css";
 
 interface BookSearchOptions {
@@ -221,10 +222,15 @@ export const Books = ({ author_id, series_id }: BookSearchOptions) => {
 		onClearSearch: () => setQuery(""),
 	});
 
-	// Only show the empty state once the active query has resolved to 0 results —
-	// never transiently while a new search is still in flight.
+	// A genuinely empty library (including first-run with the bundled library)
+	// teaches the two ways to populate it; an empty result against a non-empty
+	// library is a zero-result filter.
+	const emptyLibrary = !loading && (libraryTotal ?? 0) === 0;
+	// Only show the zero-result state once the active query has resolved to 0
+	// results — never transiently while a new search is still in flight.
 	const noMatches =
 		!loading && queryResolved && total === 0 && (libraryTotal ?? 0) > 0;
+	const trimmedQuery = query.trim();
 
 	const searchTokens = [
 		...(authorTokenName !== undefined
@@ -299,21 +305,28 @@ export const Books = ({ author_id, series_id }: BookSearchOptions) => {
 					isSearching && styles.gridAreaSearching,
 				)}
 			>
-				{noMatches ? (
-					<div className={styles.emptyState}>
-						<span className={styles.emptyText}>
-							No books match these filters.
-						</span>
-						<Button
-							variant="subtle"
-							onClick={() => {
-								resetToAllBooks();
-								onClearDeepLinkFilter();
-							}}
-						>
-							Show all books
-						</Button>
-					</div>
+				{emptyLibrary ? (
+					<EmptyLibrary />
+				) : noMatches ? (
+					trimmedQuery.length > 0 ? (
+						<EmptyState title={`No books match “${trimmedQuery}”`}>
+							<Button variant="default" onClick={() => setQuery("")}>
+								Clear search
+							</Button>
+						</EmptyState>
+					) : (
+						<EmptyState title="No books match these filters.">
+							<Button
+								variant="default"
+								onClick={() => {
+									resetToAllBooks();
+									onClearDeepLinkFilter();
+								}}
+							>
+								Show all books
+							</Button>
+						</EmptyState>
+					)
 				) : (
 					<BookGrid
 						bookList={books}

--- a/src/lib/hooks/use-open-settings.ts
+++ b/src/lib/hooks/use-open-settings.ts
@@ -1,0 +1,21 @@
+import { useNavigate } from "@tanstack/react-router";
+import { isTauri } from "@tauri-apps/api/core";
+import { useCallback } from "react";
+import { commands } from "@/bindings";
+
+/**
+ * Opens the Settings UI. Settings live in their own window on the desktop; the
+ * Rust command owns the window options and focuses the existing window if one
+ * is already open. On the web there is no second window, so we route to the
+ * in-app /settings page instead.
+ */
+export const useOpenSettings = (): (() => void) => {
+	const navigate = useNavigate();
+	return useCallback(() => {
+		if (isTauri()) {
+			void commands.clbCmdOpenSettings();
+		} else {
+			void navigate({ to: "/settings" });
+		}
+	}, [navigate]);
+};

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import {
 import clsx from "clsx";
 import { useState } from "react";
 import { F7SidebarLeft } from "@/components/icons/F7SidebarLeft";
-import { AddBookButton } from "@/components/organisms/AddBook";
+import { AddBookButton, AddBookProvider } from "@/components/organisms/AddBook";
 import { Sidebar } from "@/components/organisms/Sidebar";
 import { IconButton } from "@/components/ui";
 import { useAppKeymap } from "@/lib/hooks/use-app-keymap";
@@ -29,43 +29,45 @@ const Root = () => {
 	}
 
 	return (
-		<div
-			className={classes.shell}
-			data-sidebar-open={desktopOpened || undefined}
-			data-mobile-sidebar-open={mobileOpened || undefined}
-		>
-			<header className={classes.header} data-tauri-drag-region>
-				<div className={classes.headerControls} data-tauri-drag-region>
-					<IconButton
-						aria-label="Toggle sidebar"
-						className={clsx(classes.sidebarToggle, classes.mobileOnly)}
-						onClick={() => setMobileOpened((open) => !open)}
-					>
-						<F7SidebarLeft title="Toggle sidebar" />
-					</IconButton>
-					<IconButton
-						aria-label="Toggle sidebar"
-						className={clsx(classes.sidebarToggle, classes.desktopOnly)}
-						onClick={() => setDesktopOpened((open) => !open)}
-					>
-						<F7SidebarLeft title="Toggle sidebar" />
-					</IconButton>
-					<AddBookButton />
-				</div>
-			</header>
-
-			<div className={classes.body}>
-				<nav className={classes.nav}>
-					<Sidebar />
-				</nav>
-
-				<main className={classes.main}>
-					<div className={classes.content}>
-						<Outlet />
+		<AddBookProvider>
+			<div
+				className={classes.shell}
+				data-sidebar-open={desktopOpened || undefined}
+				data-mobile-sidebar-open={mobileOpened || undefined}
+			>
+				<header className={classes.header} data-tauri-drag-region>
+					<div className={classes.headerControls} data-tauri-drag-region>
+						<IconButton
+							aria-label="Toggle sidebar"
+							className={clsx(classes.sidebarToggle, classes.mobileOnly)}
+							onClick={() => setMobileOpened((open) => !open)}
+						>
+							<F7SidebarLeft title="Toggle sidebar" />
+						</IconButton>
+						<IconButton
+							aria-label="Toggle sidebar"
+							className={clsx(classes.sidebarToggle, classes.desktopOnly)}
+							onClick={() => setDesktopOpened((open) => !open)}
+						>
+							<F7SidebarLeft title="Toggle sidebar" />
+						</IconButton>
+						<AddBookButton />
 					</div>
-				</main>
+				</header>
+
+				<div className={classes.body}>
+					<nav className={classes.nav}>
+						<Sidebar />
+					</nav>
+
+					<main className={classes.main}>
+						<div className={classes.content}>
+							<Outlet />
+						</div>
+					</main>
+				</div>
 			</div>
-		</div>
+		</AddBookProvider>
 	);
 };
 


### PR DESCRIPTION
A brand-new (bundled empty) library rendered a silent blank grid, and a zero-result search never named the query. Both moments now teach.

- **Empty library** — an inline content-area state (not a modal) offering **Add Book…** and **Switch library…**. Shared by the Books and Authors pages.
- **No results** — states the query (`No books match "…"`) and offers a one-click **Clear search**; non-query filters keep the existing reset action.

To trigger the import flow from the empty state as well as the toolbar, the Add Book flow is lifted into an `AddBookProvider` exposing `useAddBook()`; `AddBookButton` becomes a thin consumer. The open-settings logic is extracted to a shared `useOpenSettings` hook (sidebar + empty state). Visual treatment is the quiet, illustration-free style DESIGN.md calls for via a new shared `EmptyState` component.

Verified with `vite build` (compiles) and `biome` lint clean on changed files. Runtime verification of the desktop app wasn't possible in this Linux sandbox (the run-citadel skill targets macOS/Tauri), so a quick first-run check against the bundled empty library is worth doing on review.