### PR TITLE
test: stress-library generator and query benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "citadel-rs"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "diesel",
@@ -2477,6 +2477,8 @@ dependencies = [
  "num-traits",
  "png 0.18.1",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -2728,6 +2730,8 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "epub",
+ "fastrand",
+ "image",
  "insta",
  "mobi",
  "proptest",

--- a/crates/libcalibre/Cargo.toml
+++ b/crates/libcalibre/Cargo.toml
@@ -19,6 +19,8 @@ uuid = { version = "1.6.1", features = [ "v4", "fast-rng", ] }
 sanitise-file-name = "1.0.0"
 
 [dev-dependencies]
+fastrand = "2.3"
+image = { version = "0.25", default-features = false, features = ["jpeg"] }
 insta = { version = "1.40", features = ["yaml"] }
 proptest = "1.4"
 rusqlite = "0.32"

--- a/crates/libcalibre/examples/bench_library_queries.rs
+++ b/crates/libcalibre/examples/bench_library_queries.rs
@@ -1,0 +1,582 @@
+//! Time libcalibre's query paths against an existing Calibre library.
+//!
+//! Runs each scenario several times after warmup and prints a markdown table
+//! of min/median/max wall-clock milliseconds, then dumps EXPLAIN QUERY PLAN
+//! output and the schema's index inventory for the hot queries.
+//!
+//! Usage:
+//!
+//! ```sh
+//! cargo run --release -p libcalibre --example bench_library_queries -- \
+//!     --library /path/to/library [--runs 7] [--warmup 2] [--expect-total 5000]
+//! ```
+//!
+//! Caveat: the real app's Authors/Books pages additionally stat one cover
+//! file per book in src-tauri (book_cover_image); that filesystem cost is
+//! outside libcalibre and is NOT measured here.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use diesel::sql_types::{BigInt, Integer, Text};
+use diesel::{sql_query, RunQueryDsl, SqliteConnection};
+
+use libcalibre::persistence::establish_connection;
+use libcalibre::util::get_db_path;
+use libcalibre::{AuthorId, BookQuery, BookSortOrder, CustomColumnKind, Library};
+
+const PAGE_SIZE: i64 = 100;
+
+struct Args {
+    library: PathBuf,
+    runs: usize,
+    warmup: usize,
+    expect_total: Option<i64>,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut library: Option<PathBuf> = None;
+    let mut runs = 7;
+    let mut warmup = 2;
+    let mut expect_total = None;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--library" => {
+                let value = args.next().ok_or("--library requires a path")?;
+                library = Some(PathBuf::from(value));
+            }
+            "--runs" => {
+                let value = args.next().ok_or("--runs requires a number")?;
+                runs = value.parse().map_err(|_| "invalid --runs")?;
+            }
+            "--warmup" => {
+                let value = args.next().ok_or("--warmup requires a number")?;
+                warmup = value.parse().map_err(|_| "invalid --warmup")?;
+            }
+            "--expect-total" => {
+                let value = args.next().ok_or("--expect-total requires a number")?;
+                expect_total = Some(value.parse().map_err(|_| "invalid --expect-total")?);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+
+    Ok(Args {
+        library: library.ok_or("--library <path> is required")?,
+        runs: runs.max(1),
+        warmup,
+        expect_total,
+    })
+}
+
+// =============================================================================
+// Timing helpers
+// =============================================================================
+
+struct Measurement {
+    name: String,
+    /// Sorted run times in milliseconds.
+    times_ms: Vec<f64>,
+    /// Result-size note printed alongside the scenario (e.g. rows returned).
+    note: String,
+}
+
+impl Measurement {
+    fn min(&self) -> f64 {
+        *self.times_ms.first().unwrap_or(&0.0)
+    }
+    fn median(&self) -> f64 {
+        let n = self.times_ms.len();
+        if n == 0 {
+            return 0.0;
+        }
+        if n % 2 == 1 {
+            self.times_ms[n / 2]
+        } else {
+            (self.times_ms[n / 2 - 1] + self.times_ms[n / 2]) / 2.0
+        }
+    }
+    fn max(&self) -> f64 {
+        *self.times_ms.last().unwrap_or(&0.0)
+    }
+}
+
+fn bench<F>(name: &str, runs: usize, warmup: usize, mut scenario: F) -> Measurement
+where
+    F: FnMut() -> String,
+{
+    let mut note = String::new();
+    for _ in 0..warmup {
+        note = scenario();
+    }
+    let mut times_ms = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let start = Instant::now();
+        note = scenario();
+        times_ms.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+    times_ms.sort_by(|a, b| a.partial_cmp(b).expect("non-NaN timing"));
+    Measurement {
+        name: name.to_string(),
+        times_ms,
+        note,
+    }
+}
+
+// =============================================================================
+// Raw-SQL helpers (token/author/series discovery, EXPLAIN, index listing)
+// =============================================================================
+
+#[derive(diesel::QueryableByName)]
+struct TitleRow {
+    #[diesel(sql_type = Text)]
+    title: String,
+}
+
+#[derive(diesel::QueryableByName)]
+struct IdCountRow {
+    #[diesel(sql_type = Integer)]
+    id: i32,
+    #[diesel(sql_type = BigInt)]
+    c: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct ExplainRow {
+    #[diesel(sql_type = Integer)]
+    #[allow(dead_code)]
+    id: i32,
+    #[diesel(sql_type = Integer)]
+    #[allow(dead_code)]
+    parent: i32,
+    #[diesel(sql_type = Integer)]
+    #[allow(dead_code)]
+    notused: i32,
+    #[diesel(sql_type = Text)]
+    detail: String,
+}
+
+#[derive(diesel::QueryableByName)]
+struct IndexRow {
+    #[diesel(sql_type = Text)]
+    name: String,
+    #[diesel(sql_type = Text)]
+    tbl_name: String,
+    #[diesel(sql_type = Text)]
+    sql: String,
+}
+
+/// Most/least frequent title tokens. Used to pick a "common" and a "rare"
+/// search needle without hardcoding the generator's vocabulary.
+fn pick_search_tokens(conn: &mut SqliteConnection) -> (String, String) {
+    let titles: Vec<TitleRow> = sql_query("SELECT title FROM books")
+        .load(conn)
+        .unwrap_or_default();
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for row in &titles {
+        for token in row
+            .title
+            .split(|c: char| !c.is_alphanumeric())
+            .filter(|t| t.len() >= 3)
+        {
+            *counts.entry(token.to_lowercase()).or_default() += 1;
+        }
+    }
+
+    let common = counts
+        .iter()
+        .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+        .map(|(token, _)| token.clone())
+        .unwrap_or_else(|| "the".to_string());
+    let rare = counts
+        .iter()
+        .min_by(|a, b| a.1.cmp(b.1).then(a.0.cmp(b.0)))
+        .map(|(token, _)| token.clone())
+        .unwrap_or_else(|| "zzzunmatched".to_string());
+
+    println!(
+        "Search needles: common='{common}' ({} title hits), rare='{rare}' ({} title hits)",
+        counts.get(&common).copied().unwrap_or(0),
+        counts.get(&rare).copied().unwrap_or(0)
+    );
+    (common, rare)
+}
+
+fn most_linked(conn: &mut SqliteConnection, link_table: &str, column: &str) -> Option<(i32, i64)> {
+    let rows: Vec<IdCountRow> = sql_query(format!(
+        "SELECT {column} AS id, COUNT(*) AS c FROM {link_table} \
+         GROUP BY {column} ORDER BY c DESC, id ASC LIMIT 1"
+    ))
+    .load(conn)
+    .ok()?;
+    rows.first().map(|row| (row.id, row.c))
+}
+
+fn explain(conn: &mut SqliteConnection, label: &str, sql: &str, text_binds: usize) {
+    println!("\n### EXPLAIN QUERY PLAN: {label}\n");
+    println!("```sql\n{sql}\n```\n");
+
+    let explain_sql = format!("EXPLAIN QUERY PLAN {sql}");
+    let result: Result<Vec<ExplainRow>, _> = match text_binds {
+        0 => sql_query(explain_sql).load(conn),
+        3 => sql_query(explain_sql)
+            .bind::<Text, _>("%war%")
+            .bind::<Text, _>("%war%")
+            .bind::<Text, _>("%war%")
+            .load(conn),
+        n => {
+            println!("(unsupported bind count {n})");
+            return;
+        }
+    };
+
+    match result {
+        Ok(rows) => {
+            for row in rows {
+                println!("- {}", row.detail);
+            }
+        }
+        Err(e) => println!("(explain failed: {e})"),
+    }
+}
+
+fn list_indexes(conn: &mut SqliteConnection) {
+    println!("\n### Indexes on books/authors/series/tags/link tables\n");
+    let rows: Vec<IndexRow> = sql_query(
+        "SELECT name, tbl_name, COALESCE(sql, '(implicit: UNIQUE/PK)') AS sql \
+         FROM sqlite_master WHERE type = 'index' AND (\
+           tbl_name IN ('books','authors','series','tags','identifiers','data',\
+                        'books_authors_link','books_series_link','books_tags_link') \
+           OR tbl_name LIKE 'custom_column%') \
+         ORDER BY tbl_name, name",
+    )
+    .load(conn)
+    .unwrap_or_default();
+
+    println!("| Table | Index | Definition |");
+    println!("| --- | --- | --- |");
+    for row in rows {
+        println!("| {} | {} | `{}` |", row.tbl_name, row.name, row.sql);
+    }
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+fn main() {
+    if let Err(message) = run() {
+        eprintln!("error: {message}");
+        eprintln!(
+            "usage: bench_library_queries --library <path> [--runs N] [--warmup N] [--expect-total N]"
+        );
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = parse_args()?;
+    let library_str = args
+        .library
+        .to_str()
+        .ok_or("library path is not valid UTF-8")?
+        .to_string();
+
+    let valid_path = get_db_path(&library_str)
+        .ok_or_else(|| format!("no metadata.db found under {library_str}"))?;
+    let mut library =
+        Library::new(valid_path).map_err(|e| format!("failed to open library: {e}"))?;
+
+    // A second connection for raw-SQL discovery and EXPLAIN; it never runs
+    // while a timed scenario is in flight.
+    let db_path = args.library.join("metadata.db");
+    let mut raw_conn = establish_connection(db_path.to_str().ok_or("non-UTF-8 db path")?)
+        .map_err(|_| "failed to open raw connection".to_string())?;
+
+    // ---- Sanity check + scenario inputs --------------------------------
+    let first_page = library
+        .query_books(BookQuery {
+            limit: Some(PAGE_SIZE),
+            ..BookQuery::default()
+        })
+        .map_err(|e| format!("query_books failed: {e}"))?;
+    let total = first_page.total;
+    println!(
+        "Library: {library_str}\nTotal books: {total}; first page hydrated {} items",
+        first_page.items.len()
+    );
+    if first_page.items.is_empty() {
+        return Err("library is empty; nothing to measure".to_string());
+    }
+    if let Some(expected) = args.expect_total {
+        if total != expected {
+            return Err(format!("expected total {expected}, got {total}"));
+        }
+        let hydrated = &first_page.items[0];
+        if hydrated.uuid.is_empty() || hydrated.authors.is_empty() {
+            return Err("first page items are not fully hydrated".to_string());
+        }
+        println!("Sanity check passed: total == {expected}, page is hydrated");
+    }
+
+    let (common_token, rare_token) = pick_search_tokens(&mut raw_conn);
+    let (prolific_author, author_books) =
+        most_linked(&mut raw_conn, "books_authors_link", "author")
+            .ok_or("no books_authors_link rows")?;
+    let (busy_series, series_books) = most_linked(&mut raw_conn, "books_series_link", "series")
+        .ok_or("no books_series_link rows")?;
+    println!(
+        "Filters: author {prolific_author} ({author_books} books), series {busy_series} ({series_books} books)"
+    );
+
+    let middle_offset = (total / 2 / PAGE_SIZE) * PAGE_SIZE;
+    let last_offset = ((total - 1).max(0) / PAGE_SIZE) * PAGE_SIZE;
+
+    let page_query = |offset: i64, sort: BookSortOrder| BookQuery {
+        sort,
+        limit: Some(PAGE_SIZE),
+        offset,
+        ..BookQuery::default()
+    };
+
+    // ---- Scenarios ------------------------------------------------------
+    let mut results: Vec<Measurement> = Vec::new();
+    let runs = args.runs;
+    let warmup = args.warmup;
+
+    {
+        let mut page_scenario = |name: &str, query: BookQuery| {
+            let library = &mut library;
+            let q = query;
+            bench(name, runs, warmup, move || {
+                let page = library.query_books(q.clone()).expect("query_books");
+                format!("{} rows / total {}", page.items.len(), page.total)
+            })
+        };
+
+        results.push(page_scenario(
+            "query_books: page 1 (offset 0, limit 100, title asc)",
+            page_query(0, BookSortOrder::TitleAsc),
+        ));
+        results.push(page_scenario(
+            &format!("query_books: middle page (offset {middle_offset})"),
+            page_query(middle_offset, BookSortOrder::TitleAsc),
+        ));
+        results.push(page_scenario(
+            &format!("query_books: last page (offset {last_offset})"),
+            page_query(last_offset, BookSortOrder::TitleAsc),
+        ));
+        results.push(page_scenario(
+            "query_books: sort title desc",
+            page_query(0, BookSortOrder::TitleDesc),
+        ));
+        results.push(page_scenario(
+            "query_books: sort author asc",
+            page_query(0, BookSortOrder::AuthorAsc),
+        ));
+        results.push(page_scenario(
+            "query_books: sort author desc",
+            page_query(0, BookSortOrder::AuthorDesc),
+        ));
+        results.push(page_scenario(
+            &format!("query_books: text search common ('{common_token}')"),
+            BookQuery {
+                text: Some(common_token.clone()),
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            &format!("query_books: text search rare ('{rare_token}')"),
+            BookQuery {
+                text: Some(rare_token.clone()),
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            "query_books: text search literal '%'",
+            BookQuery {
+                text: Some("%".to_string()),
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            &format!("query_books: author_id filter ({prolific_author})"),
+            BookQuery {
+                author_id: Some(AuthorId(prolific_author)),
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            &format!("query_books: series_id filter ({busy_series})"),
+            BookQuery {
+                series_id: Some(busy_series),
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            "query_books: hide_read",
+            BookQuery {
+                hide_read: true,
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            &format!("query_books: text ('{common_token}') + hide_read"),
+            BookQuery {
+                text: Some(common_token.clone()),
+                hide_read: true,
+                limit: Some(PAGE_SIZE),
+                ..BookQuery::default()
+            },
+        ));
+        results.push(page_scenario(
+            "query_books: count only (limit 0)",
+            BookQuery {
+                limit: Some(0),
+                ..BookQuery::default()
+            },
+        ));
+    }
+
+    results.push(bench(
+        &format!("search_books('{common_token}') [unbounded hydration]"),
+        runs,
+        warmup,
+        || {
+            let books = library.search_books(&common_token).expect("search_books");
+            format!("{} rows", books.len())
+        },
+    ));
+    results.push(bench(
+        &format!("find_by_author({prolific_author}) [unbounded hydration]"),
+        runs,
+        warmup,
+        || {
+            let books = library
+                .find_by_author(AuthorId(prolific_author))
+                .expect("find_by_author");
+            format!("{} rows", books.len())
+        },
+    ));
+    results.push(bench("list_series()", runs, warmup, || {
+        let series = library.list_series().expect("list_series");
+        format!("{} rows", series.len())
+    }));
+    results.push(bench(
+        "books() [full hydration of every book — Authors page path]",
+        runs,
+        warmup,
+        || {
+            let books = library.books().expect("books()");
+            format!("{} rows", books.len())
+        },
+    ));
+    results.push(bench("authors() [startup-eager]", runs, warmup, || {
+        let authors = library.authors().expect("authors()");
+        format!("{} rows", authors.len())
+    }));
+
+    // ---- Report ----------------------------------------------------------
+    println!("\n## Benchmark results ({runs} runs after {warmup} warmup, ms)\n");
+    println!("| Scenario | min | median | max | result |");
+    println!("| --- | ---: | ---: | ---: | --- |");
+    for m in &results {
+        println!(
+            "| {} | {:.2} | {:.2} | {:.2} | {} |",
+            m.name,
+            m.min(),
+            m.median(),
+            m.max(),
+            m.note
+        );
+    }
+
+    println!(
+        "\nNote: in the real app, hydrating books also costs one cover-file \
+         stat per book in src-tauri (book_cover_image); that filesystem work \
+         happens outside libcalibre and is not included in these numbers."
+    );
+
+    // ---- EXPLAIN QUERY PLAN ----------------------------------------------
+    // These SQL strings mirror what queries/books.rs::filter_where_sql /
+    // order_by_sql generate; keep them in sync when the crate changes.
+    let author_sort_expr = "(SELECT a.sort FROM books_authors_link bal \
+         JOIN authors a ON a.id = bal.author \
+         WHERE bal.book = books.id ORDER BY bal.id LIMIT 1)";
+    let text_where = "(books.title LIKE ? ESCAPE '\\' \
+              OR EXISTS (SELECT 1 FROM books_authors_link bal \
+                         JOIN authors a ON a.id = bal.author \
+                         WHERE bal.book = books.id AND a.name LIKE ? ESCAPE '\\') \
+              OR EXISTS (SELECT 1 FROM books_series_link bsl \
+                         JOIN series s ON s.id = bsl.series \
+                         WHERE bsl.book = books.id AND s.name LIKE ? ESCAPE '\\'))";
+
+    println!("\n## Query plans\n");
+    explain(
+        &mut raw_conn,
+        "paged ids, no filter, ORDER BY title",
+        "SELECT books.id FROM books WHERE 1=1 \
+         ORDER BY books.sort ASC, books.id ASC LIMIT 100 OFFSET 0",
+        0,
+    );
+    explain(
+        &mut raw_conn,
+        "paged ids, no filter, ORDER BY author sort",
+        &format!(
+            "SELECT books.id FROM books WHERE 1=1 \
+             ORDER BY {author_sort_expr} ASC, books.id ASC LIMIT 100 OFFSET 0"
+        ),
+        0,
+    );
+    explain(
+        &mut raw_conn,
+        "paged ids, text filter, ORDER BY title",
+        &format!(
+            "SELECT books.id FROM books WHERE 1=1 AND {text_where} \
+             ORDER BY books.sort ASC, books.id ASC LIMIT 100 OFFSET 0"
+        ),
+        3,
+    );
+    explain(
+        &mut raw_conn,
+        "count, text filter",
+        &format!("SELECT COUNT(*) AS total FROM books WHERE 1=1 AND {text_where}"),
+        3,
+    );
+
+    let read_column = library.custom_columns().ok().and_then(|columns| {
+        columns
+            .into_iter()
+            .find(|c| c.label == "read" && c.kind == CustomColumnKind::Bool)
+    });
+    if let Some(column) = read_column {
+        explain(
+            &mut raw_conn,
+            "paged ids, hide_read, ORDER BY title",
+            &format!(
+                "SELECT books.id FROM books WHERE 1=1 AND \
+                 NOT EXISTS (SELECT 1 FROM custom_column_{} cc \
+                 WHERE cc.book = books.id AND cc.value != 0) \
+                 ORDER BY books.sort ASC, books.id ASC LIMIT 100 OFFSET 0",
+                column.id
+            ),
+            0,
+        );
+    } else {
+        println!("\n(no `read` bool custom column; skipping hide_read EXPLAIN)");
+    }
+
+    list_indexes(&mut raw_conn);
+
+    Ok(())
+}

--- a/crates/libcalibre/examples/generate_stress_library.rs
+++ b/crates/libcalibre/examples/generate_stress_library.rs
@@ -1,0 +1,792 @@
+//! Generate a large, deterministic Calibre library for performance testing.
+//!
+//! Bootstraps an empty library from the test fixture `metadata.db`, then
+//! populates it exclusively through libcalibre's real write paths
+//! (`Library::add_book`, `set_book_cover`, `set_book_read_state`,
+//! `upsert_book_identifier`) so the result matches what the app produces.
+//!
+//! Usage:
+//!
+//! ```sh
+//! cargo run --release -p libcalibre --example generate_stress_library -- \
+//!     --dest /tmp/stress-library --books 5000 --seed 20260612
+//! ```
+//!
+//! Output is deterministic for a given (--books, --seed) pair, except for
+//! row timestamps and UUIDs which the database generates at insert time.
+
+use std::collections::{HashMap, HashSet};
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use libcalibre::persistence::establish_connection;
+use libcalibre::util::get_db_path;
+use libcalibre::{BookAdd, Library};
+
+const DEFAULT_BOOKS: usize = 5000;
+const DEFAULT_SEED: u64 = 20260612;
+const COVER_WIDTH: u32 = 150;
+const COVER_HEIGHT: u32 = 230;
+const COVER_TEMPLATE_COUNT: usize = 16;
+
+struct Args {
+    dest: PathBuf,
+    books: usize,
+    seed: u64,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut dest: Option<PathBuf> = None;
+    let mut books = DEFAULT_BOOKS;
+    let mut seed = DEFAULT_SEED;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--dest" => {
+                let value = args.next().ok_or("--dest requires a path")?;
+                dest = Some(PathBuf::from(value));
+            }
+            "--books" => {
+                let value = args.next().ok_or("--books requires a number")?;
+                books = value
+                    .parse()
+                    .map_err(|_| format!("invalid --books value: {value}"))?;
+            }
+            "--seed" => {
+                let value = args.next().ok_or("--seed requires a u64")?;
+                seed = value
+                    .parse()
+                    .map_err(|_| format!("invalid --seed value: {value}"))?;
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+
+    let dest = dest.ok_or("--dest <path> is required")?;
+    if books == 0 {
+        return Err("--books must be at least 1".to_string());
+    }
+    Ok(Args { dest, books, seed })
+}
+
+// =============================================================================
+// Vocabulary
+// =============================================================================
+
+const FIRST_NAMES: &[&str] = &[
+    "Ada", "Bram", "Clara", "Dmitri", "Elena", "Farid", "Greta", "Hideo", "Ingrid", "Jamal",
+    "Keiko", "Lars", "Mona", "Nadia", "Otto", "Priya", "Quentin", "Rosa", "Sven", "Tomoko",
+    "Ulrich", "Vera", "Wendell", "Ximena", "Yusuf", "Zora", "Anders", "Beatriz", "Cormac",
+    "Daphne", "Emeka", "Frances", "Gustav", "Halima", "Ivar", "Jolene", "Kazimir", "Leona",
+    "Marcus", "Noor",
+];
+
+const LAST_NAMES: &[&str] = &[
+    "Aldercroft",
+    "Bellweather",
+    "Cardamine",
+    "Dunmore",
+    "Eastvale",
+    "Fenwick",
+    "Grimaldi",
+    "Halloran",
+    "Ivanenko",
+    "Jankowski",
+    "Kettleburn",
+    "Larkspur",
+    "Montrose",
+    "Nightingale",
+    "Okonkwo",
+    "Pemberton",
+    "Quayle",
+    "Ravenscroft",
+    "Silverthorne",
+    "Thackeray",
+    "Umarov",
+    "Vandermeer",
+    "Wexford",
+    "Yarrow",
+    "Zhukova",
+    "Ashgrove",
+    "Birchall",
+    "Crowhurst",
+    "Davenport",
+    "Ellsworth",
+    "Featherstone",
+    "Galloway",
+    "Hawthorne",
+    "Ironwood",
+    "Juniper",
+    "Kingsley",
+    "Lockridge",
+    "Marlowe",
+    "Northgate",
+    "O'Malley",
+    "Palewski",
+    "Quintrell",
+    "Redmane",
+    "Strandberg",
+    "Tanaka",
+    "Underhill",
+    "Voss",
+    "Whitlock",
+    "Xiang",
+    "Yamamoto",
+];
+
+const TITLE_ADJECTIVES: &[&str] = &[
+    "Silent",
+    "Crimson",
+    "Forgotten",
+    "Last",
+    "Hidden",
+    "Burning",
+    "Hollow",
+    "Endless",
+    "Iron",
+    "Pale",
+    "Wandering",
+    "Shattered",
+    "Gilded",
+    "Restless",
+    "Distant",
+    "Broken",
+    "Sleeping",
+    "Wicked",
+    "Quiet",
+    "Golden",
+];
+
+const TITLE_NOUNS: &[&str] = &[
+    "Shadow",
+    "War",
+    "Garden",
+    "River",
+    "Crown",
+    "Empire",
+    "Winter",
+    "Mirror",
+    "Voyage",
+    "Cipher",
+    "Harvest",
+    "Lantern",
+    "Archive",
+    "Tempest",
+    "Orchard",
+    "Citadel",
+    "Compass",
+    "Reckoning",
+    "Threshold",
+    "Labyrinth",
+    "Sparrow",
+    "Ember",
+    "Atlas",
+    "Requiem",
+    "Meridian",
+];
+
+const TITLE_TRAILERS: &[&str] = &[
+    "A Novel",
+    "Collected Stories",
+    "The Complete Edition",
+    "Book One",
+    "An Oral History",
+    "Notes from the Field",
+];
+
+/// Title fragments hostile to naive LIKE queries: literal `%`, `_`,
+/// apostrophes, and non-ASCII text.
+const HOSTILE_TITLES: &[&str] = &[
+    "100% Doomed",
+    "The 50% Solution",
+    "snake_case and Other Disasters",
+    "under_score: a programmer's lament",
+    "O'Malley's Last % Stand",
+    "L'Étranger Revisited",
+    "Caffè Notturno",
+    "Königskinder",
+    "戦争と平和 (Annotated)",
+    "Война и мир, Abridged",
+    "Naïve Düsk",
+    "It's 100%_certain",
+];
+
+const SERIES_PATTERNS: &[&str] = &[
+    "{} Saga",
+    "The {} Cycle",
+    "{} Chronicles",
+    "Tales of the {}",
+];
+
+const TAG_POOL: &[&str] = &[
+    "science-fiction",
+    "fantasy",
+    "mystery",
+    "thriller",
+    "romance",
+    "horror",
+    "literary",
+    "historical",
+    "biography",
+    "memoir",
+    "philosophy",
+    "poetry",
+    "essays",
+    "travel",
+    "cooking",
+    "science",
+    "mathematics",
+    "history",
+    "politics",
+    "economics",
+    "psychology",
+    "self-help",
+    "young-adult",
+    "children",
+    "graphic-novel",
+    "short-stories",
+    "anthology",
+    "translated",
+    "award-winner",
+    "book-club",
+    "to-reread",
+    "signed-copy",
+    "first-edition",
+    "library-loan",
+    "gift",
+    "beach-read",
+    "winter-read",
+    "comfort",
+    "challenging",
+    "abandoned-once",
+    "five-stars",
+    "australian",
+    "japanese",
+    "russian",
+    "french",
+    "nigerian",
+    "canadian",
+    "debut",
+    "novella",
+    "doorstopper",
+];
+
+// =============================================================================
+// Deterministic content builders
+// =============================================================================
+
+fn build_author_pool(rng: &mut fastrand::Rng, size: usize) -> Vec<String> {
+    let mut pool = Vec::with_capacity(size);
+    let mut seen = HashSet::new();
+    while pool.len() < size {
+        let first = FIRST_NAMES[rng.usize(..FIRST_NAMES.len())];
+        let last = LAST_NAMES[rng.usize(..LAST_NAMES.len())];
+        let name = if pool.len() % 7 == 3 {
+            // Sprinkle middle initials so name collisions stay rare.
+            let initial = (b'A' + rng.u8(..26)) as char;
+            format!("{first} {initial}. {last}")
+        } else {
+            format!("{first} {last}")
+        };
+        if seen.insert(name.clone()) {
+            pool.push(name);
+        }
+    }
+    pool
+}
+
+/// Weighted author pick: low indices are chosen far more often, so the pool
+/// contains a handful of prolific authors and a long tail.
+fn weighted_author_index(rng: &mut fastrand::Rng, pool_len: usize) -> usize {
+    let r = rng.f64();
+    ((pool_len as f64) * r.powf(2.5)) as usize % pool_len
+}
+
+fn build_title(rng: &mut fastrand::Rng) -> String {
+    // ~4% of titles carry LIKE-hostile characters.
+    if rng.f64() < 0.04 {
+        return HOSTILE_TITLES[rng.usize(..HOSTILE_TITLES.len())].to_string();
+    }
+
+    let adjective = TITLE_ADJECTIVES[rng.usize(..TITLE_ADJECTIVES.len())];
+    let noun = TITLE_NOUNS[rng.usize(..TITLE_NOUNS.len())];
+    let second_noun = TITLE_NOUNS[rng.usize(..TITLE_NOUNS.len())];
+
+    let base = match rng.usize(..5) {
+        0 => format!("The {adjective} {noun}"),
+        1 => format!("{adjective} {noun}"),
+        2 => format!("{noun} of {second_noun}s"),
+        3 => format!("A {noun} for the {adjective} {second_noun}"),
+        _ => format!("The {noun} and the {second_noun}"),
+    };
+
+    if rng.f64() < 0.15 {
+        let trailer = TITLE_TRAILERS[rng.usize(..TITLE_TRAILERS.len())];
+        format!("{base}: {trailer}")
+    } else {
+        base
+    }
+}
+
+#[derive(Clone)]
+struct SeriesSlot {
+    name: String,
+    index: f32,
+    author_index: usize,
+}
+
+/// Pre-plan series membership: ~30% of books belong to a series of 3-15
+/// books. Each series has a dedicated primary author. Slots are shuffled so
+/// series members are scattered across insertion order.
+fn build_series_schedule(
+    rng: &mut fastrand::Rng,
+    book_count: usize,
+    author_pool_len: usize,
+) -> Vec<Option<SeriesSlot>> {
+    let target = (book_count as f64 * 0.30) as usize;
+    let mut slots: Vec<Option<SeriesSlot>> = vec![None; book_count];
+    let mut covered = 0;
+    let mut series_number = 0;
+
+    while covered < target {
+        series_number += 1;
+        let size = rng.usize(3..=15).min(target - covered).max(1);
+        let pattern = SERIES_PATTERNS[rng.usize(..SERIES_PATTERNS.len())];
+        let noun = TITLE_NOUNS[rng.usize(..TITLE_NOUNS.len())];
+        let name = format!("{} #{series_number}", pattern.replace("{}", noun));
+        let author_index = weighted_author_index(rng, author_pool_len);
+
+        for position in 0..size {
+            slots[covered + position] = Some(SeriesSlot {
+                name: name.clone(),
+                index: (position + 1) as f32,
+                author_index,
+            });
+        }
+        covered += size;
+    }
+
+    rng.shuffle(&mut slots);
+    slots
+}
+
+fn build_pubdate(rng: &mut fastrand::Rng) -> chrono::NaiveDate {
+    let year = rng.i32(1950..=2024);
+    let month = rng.u32(1..=12);
+    let day = rng.u32(1..=28);
+    chrono::NaiveDate::from_ymd_opt(year, month, day).expect("valid synthetic date")
+}
+
+fn build_isbn13(rng: &mut fastrand::Rng) -> String {
+    let mut digits = vec![9u32, 7, 8];
+    for _ in 0..9 {
+        digits.push(rng.u32(..10));
+    }
+    let checksum: u32 = digits
+        .iter()
+        .enumerate()
+        .map(|(i, d)| if i % 2 == 0 { *d } else { 3 * *d })
+        .sum();
+    digits.push((10 - (checksum % 10)) % 10);
+    digits.into_iter().map(|d| d.to_string()).collect()
+}
+
+// =============================================================================
+// Cover templates (small solid-color JPEGs)
+// =============================================================================
+
+fn build_cover_templates(rng: &mut fastrand::Rng) -> Vec<Vec<u8>> {
+    (0..COVER_TEMPLATE_COUNT)
+        .map(|_| {
+            let pixel = image::Rgb([rng.u8(..), rng.u8(..), rng.u8(..)]);
+            let img = image::RgbImage::from_pixel(COVER_WIDTH, COVER_HEIGHT, pixel);
+            let mut bytes = Vec::new();
+            let encoder =
+                image::codecs::jpeg::JpegEncoder::new_with_quality(Cursor::new(&mut bytes), 70);
+            img.write_with_encoder(encoder)
+                .expect("encode solid-color JPEG cover");
+            bytes
+        })
+        .collect()
+}
+
+// =============================================================================
+// Stub EPUB (a valid stored ZIP, same bytes reused for every book)
+// =============================================================================
+
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = !0u32;
+    for &byte in data {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+fn build_stub_epub() -> Vec<u8> {
+    const CONTAINER_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    const CONTENT_OPF: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" unique-identifier="bookid" version="2.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Stress Test Stub</dc:title>
+    <dc:language>en</dc:language>
+    <dc:identifier id="bookid">urn:uuid:00000000-0000-4000-8000-000000000000</dc:identifier>
+  </metadata>
+  <manifest>
+    <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter1"/>
+  </spine>
+</package>"#;
+
+    let chapter_body = "The quick brown fox jumps over the lazy dog. ".repeat(48);
+    let chapter = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Chapter 1</title></head>
+<body><p>{chapter_body}</p></body></html>"#
+    );
+
+    let files: Vec<(&str, Vec<u8>)> = vec![
+        ("mimetype", b"application/epub+zip".to_vec()),
+        ("META-INF/container.xml", CONTAINER_XML.as_bytes().to_vec()),
+        ("OEBPS/content.opf", CONTENT_OPF.as_bytes().to_vec()),
+        ("OEBPS/chapter1.xhtml", chapter.into_bytes()),
+    ];
+
+    let mut out = Vec::new();
+    let mut central = Vec::new();
+    let mut entry_count = 0u16;
+
+    let push_u16 = |buf: &mut Vec<u8>, v: u16| buf.extend_from_slice(&v.to_le_bytes());
+    let push_u32 = |buf: &mut Vec<u8>, v: u32| buf.extend_from_slice(&v.to_le_bytes());
+
+    for (name, data) in &files {
+        let offset = out.len() as u32;
+        let crc = crc32(data);
+        let size = data.len() as u32;
+
+        // Local file header, method 0 (stored).
+        push_u32(&mut out, 0x0403_4b50);
+        push_u16(&mut out, 20); // version needed
+        push_u16(&mut out, 0); // flags
+        push_u16(&mut out, 0); // method: stored
+        push_u16(&mut out, 0); // mod time
+        push_u16(&mut out, 0x21); // mod date (1980-01-01)
+        push_u32(&mut out, crc);
+        push_u32(&mut out, size);
+        push_u32(&mut out, size);
+        push_u16(&mut out, name.len() as u16);
+        push_u16(&mut out, 0); // extra len
+        out.extend_from_slice(name.as_bytes());
+        out.extend_from_slice(data);
+
+        // Central directory entry.
+        push_u32(&mut central, 0x0201_4b50);
+        push_u16(&mut central, 20); // version made by
+        push_u16(&mut central, 20); // version needed
+        push_u16(&mut central, 0);
+        push_u16(&mut central, 0);
+        push_u16(&mut central, 0);
+        push_u16(&mut central, 0x21);
+        push_u32(&mut central, crc);
+        push_u32(&mut central, size);
+        push_u32(&mut central, size);
+        push_u16(&mut central, name.len() as u16);
+        push_u16(&mut central, 0);
+        push_u16(&mut central, 0);
+        push_u16(&mut central, 0); // disk number
+        push_u16(&mut central, 0); // internal attrs
+        push_u32(&mut central, 0); // external attrs
+        push_u32(&mut central, offset);
+        central.extend_from_slice(name.as_bytes());
+        entry_count += 1;
+    }
+
+    let central_offset = out.len() as u32;
+    let central_size = central.len() as u32;
+    out.extend_from_slice(&central);
+
+    // End of central directory.
+    push_u32(&mut out, 0x0605_4b50);
+    push_u16(&mut out, 0);
+    push_u16(&mut out, 0);
+    push_u16(&mut out, entry_count);
+    push_u16(&mut out, entry_count);
+    push_u32(&mut out, central_size);
+    push_u32(&mut out, central_offset);
+    push_u16(&mut out, 0); // comment len
+
+    out
+}
+
+// =============================================================================
+// Bootstrapping and pragmas
+// =============================================================================
+
+fn fixture_db_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("empty_library")
+        .join("metadata.db")
+}
+
+#[derive(diesel::QueryableByName)]
+struct JournalModeRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    #[allow(dead_code)]
+    journal_mode: String,
+}
+
+fn set_journal_mode(db_path: &str, mode: &str) -> Result<(), String> {
+    use diesel::RunQueryDsl;
+
+    let mut conn = establish_connection(db_path)
+        .map_err(|_| format!("failed to open connection to {db_path}"))?;
+    let _: Vec<JournalModeRow> = diesel::sql_query(format!("PRAGMA journal_mode = {mode}"))
+        .load(&mut conn)
+        .map_err(|e| format!("failed to set journal_mode={mode}: {e}"))?;
+    Ok(())
+}
+
+fn dir_size_bytes(path: &Path) -> u64 {
+    let mut total = 0;
+    if let Ok(entries) = std::fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let entry_path = entry.path();
+            if entry_path.is_dir() {
+                total += dir_size_bytes(&entry_path);
+            } else if let Ok(metadata) = entry.metadata() {
+                total += metadata.len();
+            }
+        }
+    }
+    total
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+fn main() {
+    if let Err(message) = run() {
+        eprintln!("error: {message}");
+        eprintln!("usage: generate_stress_library --dest <path> [--books <N>] [--seed <u64>]");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let args = parse_args()?;
+    let started = Instant::now();
+    let mut rng = fastrand::Rng::with_seed(args.seed);
+
+    if args.dest.exists() && std::fs::read_dir(&args.dest).is_ok_and(|mut d| d.next().is_some()) {
+        return Err(format!(
+            "destination {} exists and is not empty; delete it first",
+            args.dest.display()
+        ));
+    }
+    std::fs::create_dir_all(&args.dest)
+        .map_err(|e| format!("failed to create {}: {e}", args.dest.display()))?;
+
+    let fixture = fixture_db_path();
+    if !fixture.exists() {
+        return Err(format!(
+            "empty-library fixture not found at {}",
+            fixture.display()
+        ));
+    }
+    std::fs::copy(&fixture, args.dest.join("metadata.db"))
+        .map_err(|e| format!("failed to copy fixture metadata.db: {e}"))?;
+
+    let dest_str = args
+        .dest
+        .to_str()
+        .ok_or("destination path is not valid UTF-8")?
+        .to_string();
+    let db_path_str = args
+        .dest
+        .join("metadata.db")
+        .to_str()
+        .ok_or("db path is not valid UTF-8")?
+        .to_string();
+
+    // WAL keeps per-statement commit fsyncs cheap while we bulk-insert; it is
+    // restored to Calibre's default (DELETE) before the summary prints.
+    set_journal_mode(&db_path_str, "WAL")?;
+
+    let valid_path = get_db_path(&dest_str).ok_or("metadata.db missing after bootstrap")?;
+    let mut library =
+        Library::new(valid_path).map_err(|e| format!("failed to open library: {e}"))?;
+
+    // Deterministic content pools.
+    let author_pool = build_author_pool(&mut rng, (args.books / 8).max(1));
+    let series_schedule = build_series_schedule(&mut rng, args.books, author_pool.len());
+    let cover_templates = build_cover_templates(&mut rng);
+
+    // The stub EPUB is written once to a scratch file inside dest (removed
+    // at the end); add_book copies it into each book directory the same way
+    // the app's import path does.
+    let stub_epub = build_stub_epub();
+    let stub_path = args.dest.join(".stress_stub_source.epub");
+    std::fs::write(&stub_path, &stub_epub)
+        .map_err(|e| format!("failed to write stub epub: {e}"))?;
+
+    let mut authors_used: HashSet<usize> = HashSet::new();
+    let mut series_used: HashSet<String> = HashSet::new();
+    let mut tags_used: HashSet<&str> = HashSet::new();
+    let mut read_count = 0usize;
+    let mut isbn_count = 0usize;
+
+    println!(
+        "Generating {} books into {} (seed {})",
+        args.books,
+        args.dest.display(),
+        args.seed
+    );
+
+    for (book_number, scheduled_slot) in series_schedule.iter().enumerate() {
+        let series_slot = scheduled_slot.clone();
+
+        // 1-3 authors; series books keep their series' dedicated primary author.
+        let mut author_indices = Vec::new();
+        let primary = match &series_slot {
+            Some(slot) => slot.author_index,
+            None => weighted_author_index(&mut rng, author_pool.len()),
+        };
+        author_indices.push(primary);
+        let extra_authors = match rng.f64() {
+            r if r < 0.70 => 0,
+            r if r < 0.95 => 1,
+            _ => 2,
+        };
+        while author_indices.len() < 1 + extra_authors {
+            let candidate = weighted_author_index(&mut rng, author_pool.len());
+            if !author_indices.contains(&candidate) {
+                author_indices.push(candidate);
+            }
+        }
+        authors_used.extend(author_indices.iter().copied());
+        let author_names: Vec<String> = author_indices
+            .iter()
+            .map(|&i| author_pool[i].clone())
+            .collect();
+
+        let tag_count = rng.usize(0..=5);
+        let mut tags = Vec::new();
+        while tags.len() < tag_count {
+            let tag = TAG_POOL[rng.usize(..TAG_POOL.len())];
+            if !tags.contains(&tag.to_string()) {
+                tags_used.insert(tag);
+                tags.push(tag.to_string());
+            }
+        }
+
+        if let Some(slot) = &series_slot {
+            series_used.insert(slot.name.clone());
+        }
+
+        let book = BookAdd {
+            title: build_title(&mut rng),
+            author_names,
+            tags: if tags.is_empty() { None } else { Some(tags) },
+            series: series_slot.as_ref().map(|s| s.name.clone()),
+            series_index: series_slot.as_ref().map(|s| s.index),
+            publisher: None,
+            publication_date: Some(build_pubdate(&mut rng)),
+            rating: None,
+            comments: None,
+            identifiers: HashMap::new(),
+            file_paths: vec![stub_path.clone()],
+        };
+
+        let added = library
+            .add_book(book)
+            .map_err(|e| format!("add_book failed at book {book_number}: {e}"))?;
+        let book_id = added.id;
+
+        let cover = &cover_templates[rng.usize(..cover_templates.len())];
+        library
+            .set_book_cover(book_id, cover.clone())
+            .map_err(|e| format!("set_book_cover failed at book {book_number}: {e}"))?;
+
+        // ~40% read, ~15% explicitly unread, the rest left unset (Calibre's
+        // tri-state "unknown").
+        match rng.f64() {
+            r if r < 0.40 => {
+                library
+                    .set_book_read_state(book_id, true)
+                    .map_err(|e| format!("set_book_read_state failed: {e}"))?;
+                read_count += 1;
+            }
+            r if r < 0.55 => {
+                library
+                    .set_book_read_state(book_id, false)
+                    .map_err(|e| format!("set_book_read_state failed: {e}"))?;
+            }
+            _ => {}
+        }
+
+        if rng.f64() < 0.50 {
+            let isbn = build_isbn13(&mut rng);
+            library
+                .upsert_book_identifier(book_id, "isbn".to_string(), isbn, None)
+                .map_err(|e| format!("upsert_book_identifier failed: {e}"))?;
+            isbn_count += 1;
+        }
+
+        let written = book_number + 1;
+        if written % 500 == 0 || written == args.books {
+            println!(
+                "  {written}/{} books written ({:.1}s elapsed)",
+                args.books,
+                started.elapsed().as_secs_f64()
+            );
+        }
+    }
+
+    let _ = std::fs::remove_file(&stub_path);
+
+    // Restore Calibre's default journal mode (checkpoints and removes -wal).
+    drop(library);
+    set_journal_mode(&db_path_str, "DELETE")?;
+
+    let elapsed = started.elapsed();
+    let size_bytes = dir_size_bytes(&args.dest);
+    println!("\nDone.");
+    println!("  Books written:    {}", args.books);
+    println!(
+        "  Authors used:     {} (pool of {})",
+        authors_used.len(),
+        author_pool.len()
+    );
+    println!("  Series created:   {}", series_used.len());
+    println!(
+        "  Tags used:        {} (pool of {})",
+        tags_used.len(),
+        TAG_POOL.len()
+    );
+    println!("  Marked read:      {read_count}");
+    println!("  With ISBN:        {isbn_count}");
+    println!("  Elapsed:          {:.1}s", elapsed.as_secs_f64());
+    println!(
+        "  Library size:     {:.1} MiB",
+        size_bytes as f64 / (1024.0 * 1024.0)
+    );
+    println!("  Destination:      {}", args.dest.display());
+
+    Ok(())
+}


### PR DESCRIPTION
## What

Measurement tooling for Citadel performance at massive library scale. No product code paths change; this phase only produces data.

Two `libcalibre` examples (so they exercise the crate's real write/read paths):

- **`generate_stress_library`** — bootstraps an empty Calibre library from the test fixture, then populates it via `Library::add_book` / `set_book_cover` / `set_book_read_state` / `upsert_book_identifier`. Deterministic via a seeded RNG (`fastrand`): weighted author pool (~N/8, some prolific), ~30% of books in series of 3–15, 0–5 tags from a 50-tag pool, pubdates over 1950–2024, ISBNs on ~half, the `read` bool custom column set true for ~40%, LIKE-hostile titles (`%`, `_`, apostrophes, unicode), a 150x230 solid-color JPEG cover per book, and a small valid stub EPUB per book so `data` rows exist.
- **`bench_library_queries`** — times every hot query path (warmup + 7 runs, min/median/max ms, markdown table), then prints `EXPLAIN QUERY PLAN` for the paged id/count queries and the Calibre schema's index inventory.

## How to run

```sh
# Generate a 5000-book library (deterministic; ~8s, ~33 MiB)
cargo run --release -p libcalibre --example generate_stress_library -- \
    --dest ~/dev/citadel-stress-library --books 5000 --seed 20260612

# Benchmark it
cargo run --release -p libcalibre --example bench_library_queries -- \
    --library ~/dev/citadel-stress-library --expect-total 5000
```

## Headline numbers (5000 books, M-series Mac, release build)

| Scenario | median ms |
| --- | ---: |
| query_books: page 1 (title asc) | 1.6 |
| query_books: middle/last page | 4.1–4.4 |
| query_books: author-sort page | 4.0–4.3 |
| query_books: text search (common/rare/`%`) | 5.5 / 9.5 / 9.2 |
| query_books: hide_read | 4.0 |
| query_books: text + hide_read | 7.5 |
| search_books (3404 matches, unbounded hydration) | 35.1 |
| books() full hydration (Authors-page path) | 32.9 |
| authors() | 0.1 |

Key EXPLAIN findings: every paged query is `SCAN books` + `USE TEMP B-TREE FOR ORDER BY` — Calibre's schema has **no index on `books.sort`**, so sorting is recomputed per page request, and LIKE text filters scan all rows for both the page and its COUNT twin. Link tables and custom columns are well indexed (`*_aidx`/`*_bidx`, `custom_column_N (book)`). Note the real app adds one cover-file stat per book in src-tauri on top of `books()`/page hydration, which these numbers exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)