### PR TITLE
perf: remove startup pending floor; fix silent cover-load failure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,11 @@
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { useEffect } from "react";
-import { Toaster, TooltipProvider, toast } from "@/components/ui";
+import {
+	LoadingOverlay,
+	Toaster,
+	TooltipProvider,
+	toast,
+} from "@/components/ui";
 import { IS_DEV } from "@/lib/env";
 import { useInitializeLibraryStore } from "@/lib/hooks/use-initialize-library-store";
 import { usePlatform } from "@/lib/platform/context";
@@ -11,8 +16,33 @@ import { FirstTimeSetup } from "./components/pages/firstTimeSetup";
 import { routeTree } from "./routeTree.gen";
 import { useActiveLibraryPath, useSettings } from "./stores/settings/store";
 
+/**
+ * Full-window pending fallback for routes that suspend past `defaultPendingMs`
+ * (none of today's routes define a loader, but a slow future loader should
+ * show a spinner rather than a frozen blank window).
+ */
+const RoutePending = () => (
+	<div style={{ position: "relative", height: "100vh" }}>
+		<LoadingOverlay visible />
+	</div>
+);
+
 const router = createRouter({
 	routeTree,
+	// `pendingMs` = how long a match must stay pending before the pending
+	// component appears. The library store is ready ~145ms after webview load,
+	// so 150ms means the pending UI never flashes on the normal startup path
+	// but still surfaces within a frame or two of a genuinely slow load.
+	defaultPendingMs: 150,
+	// `pendingMinMs` = minimum time the pending UI stays once shown
+	// (anti-flash). It must be 0 here: in @tanstack/react-router 1.29.2 every
+	// match renders once in "pending" status during the initial load, which
+	// arms a `minPendingPromise` timer the commit then awaits — so ANY nonzero
+	// value puts that many ms of dead time between data-ready and first paint
+	// on every startup (the default 500 was measured to hold first grid paint
+	// at ~620-690ms when data was ready at ~145ms).
+	defaultPendingMinMs: 0,
+	defaultPendingComponent: RoutePending,
 });
 
 declare module "@tanstack/react-router" {

--- a/src/components/atoms/BookCover.tsx
+++ b/src/components/atoms/BookCover.tsx
@@ -1,6 +1,7 @@
 import { type HTMLAttributes, useState } from "react";
 import type { LibraryBook } from "@/bindings";
 import { formatAuthorList } from "@/lib/authors";
+import { resolveCoverLoad } from "@/lib/cover-load";
 import { selectByStringHash } from "@/lib/hash-string";
 import { shortenToChars } from "$lib/domain/book";
 
@@ -57,6 +58,24 @@ const BookCoverUsingImage = ({
 	fluid: boolean;
 } & HTMLAttributes<HTMLDivElement>) => {
 	const [isHovering, setIsHovering] = useState(false);
+	// A cover can fail without an `error` event: an asset:// URL outside the
+	// asset scope "loads" at 0×0, which would render a zero-height cell and
+	// collapse the virtualized grid's row measurement. Either failure mode
+	// falls back to the same placeholder treatment as books with no cover,
+	// whose fixed aspect ratio keeps the cell dimensions stable.
+	const [coverFailed, setCoverFailed] = useState(false);
+
+	if (coverFailed) {
+		return (
+			<BookCoverWithPlaceholder
+				book={book}
+				disableFade={disableFade}
+				fluid={fluid}
+				{...props}
+			/>
+		);
+	}
+
 	return (
 		<div
 			style={{
@@ -83,6 +102,14 @@ const BookCoverUsingImage = ({
 			<img
 				src={book.cover_image.url}
 				alt={book.title}
+				onError={() => {
+					setCoverFailed(true);
+				}}
+				onLoad={(event) => {
+					if (resolveCoverLoad(event.currentTarget) === "failed") {
+						setCoverFailed(true);
+					}
+				}}
 				style={{
 					...(fluid
 						? {
@@ -246,6 +273,9 @@ export const BookCover = ({
 	if (book.cover_image?.url !== undefined) {
 		return (
 			<BookCoverUsingImage
+				// Remounting on URL change resets the failed-cover fallback state
+				// when a book gains a (new) cover.
+				key={book.cover_image.url}
 				// @ts-expect-error `cover_image` obviously exists
 				book={book}
 				disableFade={disableFade}

--- a/src/lib/cover-load.test.ts
+++ b/src/lib/cover-load.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { resolveCoverLoad } from "./cover-load";
+
+describe("resolveCoverLoad", () => {
+	it("treats an image with real intrinsic dimensions as loaded", () => {
+		expect(resolveCoverLoad({ naturalWidth: 400, naturalHeight: 600 })).toBe(
+			"loaded",
+		);
+	});
+
+	it("treats a 0x0 'successful' load as failed (asset scope miss)", () => {
+		// WebKit fires `load`, not `error`, for asset:// URLs outside the asset
+		// scope — the image decodes to nothing.
+		expect(resolveCoverLoad({ naturalWidth: 0, naturalHeight: 0 })).toBe(
+			"failed",
+		);
+	});
+
+	it("treats a zero-width image as failed", () => {
+		expect(resolveCoverLoad({ naturalWidth: 0, naturalHeight: 600 })).toBe(
+			"failed",
+		);
+	});
+
+	it("treats a zero-height image as failed", () => {
+		expect(resolveCoverLoad({ naturalWidth: 400, naturalHeight: 0 })).toBe(
+			"failed",
+		);
+	});
+});

--- a/src/lib/cover-load.ts
+++ b/src/lib/cover-load.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure decision logic for whether a cover `<img>` actually produced pixels
+ * (BookCover.tsx).
+ *
+ * Failure is not always an `error` event: when an asset:// URL is outside the
+ * webview's asset scope (e.g. restored settings point at a library folder the
+ * user never re-picked), WebKit fires `load` with a zero-size image instead.
+ * Because grid row height derives from the image's intrinsic size, such a
+ * "successful" zero-size load collapses virtualized row measurement — so it
+ * must be treated as a failure and fall back to the placeholder cover.
+ */
+
+export type CoverLoadResolution = "loaded" | "failed";
+
+interface ImageNaturalSize {
+	naturalWidth: number;
+	naturalHeight: number;
+}
+
+/**
+ * Classifies a cover image's `load` event: only an image with real intrinsic
+ * dimensions counts as loaded; a 0×0 "load" is a failure in disguise.
+ */
+export const resolveCoverLoad = (img: ImageNaturalSize): CoverLoadResolution =>
+	img.naturalWidth > 0 && img.naturalHeight > 0 ? "loaded" : "failed";


### PR DESCRIPTION
Two measurement-backed fixes from profiling against a 5,000-book library.

## 1. Remove the 500ms startup pending floor

The library store is ready ~145ms after webview load, but the first route did not commit until ~620-660ms. The gap is TanStack Router's `defaultPendingMinMs` (default 500): in v1.29.2 every match renders once in "pending" status during the initial load, which arms a `minPendingPromise` timer that `loadMatches` awaits before committing — even for routes with no loader and no pending component (ours have neither).

New router config:

- `defaultPendingMs: 150` — the pending UI only appears after 150ms of pending, so it never flashes on the normal startup path (data resolves ~145ms) but still surfaces quickly on genuinely slow loads.
- `defaultPendingMinMs: 0` — must be 0, not merely small: any nonzero value re-arms the initial-commit floor, costing exactly that many ms on every startup. Flash risk is covered by the 150ms `pendingMs` gate; slow library loads show BookGrid's own store-driven LoadingOverlay.
- `defaultPendingComponent` — a LoadingOverlay fallback (none existed; a slow future loader would have suspended into the bare `<Suspense>` and frozen on a blank window).

**Measured** in the dev app against the 5,000-book stress library (webview load → first grid card commit, 5 warm reloads each):

| | first grid card |
|---|---|
| before | 706-742ms (median ~713ms) |
| after | 158-252ms (median ~213ms) |

## 2. Cover-load failure no longer collapses the grid

When an asset:// cover URL is outside the webview's asset scope (e.g. restored settings point at a library folder the user never re-picked), WebKit fires `load` — not `error` — with `naturalWidth = 0`. The `<img>` rendered nothing, and because shelf row height derives from image intrinsic size, every virtualized row measured near zero: the grid's scrollHeight collapsed from ~256k px to ~52k px in testing, with ~3x as many rows cramming into one viewport.

`BookCover` now treats img `error` OR load-with-zero-natural-size as a failed cover and renders the existing no-cover placeholder treatment (same component, no new design). The placeholder's fixed 133:200 aspect ratio keeps cell dimensions stable for virtualized row measurement. The pure loaded-vs-failed decision lives in `src/lib/cover-load.ts` with vitest coverage.

**Verified live** with an unscoped library path: before — 110 mounted covers, all zero-size, no fallback; after — all mounted covers render placeholders and the grid keeps its full ~260k px height.

Gates: cargo fmt / clippy / test, tsc, biome lint, vitest — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)