### PR TITLE
perf: Authors page at scale — has_cover, O(n) counts, virtualized list

### DIFF
--- a/crates/libcalibre/examples/bench_library_queries.rs
+++ b/crates/libcalibre/examples/bench_library_queries.rs
@@ -485,6 +485,15 @@ fn run() -> Result<(), String> {
         let authors = library.authors().expect("authors()");
         format!("{} rows", authors.len())
     }));
+    results.push(bench(
+        "author_book_counts() [Authors page counts, one GROUP BY]",
+        runs,
+        warmup,
+        || {
+            let counts = library.author_book_counts().expect("author_book_counts()");
+            format!("{} authors with books", counts.len())
+        },
+    ));
 
     // ---- Report ----------------------------------------------------------
     println!("\n## Benchmark results ({runs} runs after {warmup} warmup, ms)\n");

--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -511,6 +511,13 @@ impl Library {
         operations::authors::all(&mut self.conn)
     }
 
+    /// Linked-book count per author, computed in one GROUP BY pass over
+    /// `books_authors_link` (no per-author scans). Authors with no linked
+    /// books are absent from the map — treat a missing entry as 0.
+    pub fn author_book_counts(&mut self) -> Result<HashMap<AuthorId, i64>, CalibreError> {
+        author_queries::book_counts(&mut self.conn)
+    }
+
     pub fn get_author(&mut self, author_id: AuthorId) -> Result<Author, CalibreError> {
         operations::authors::get(&mut self.conn, author_id)
     }

--- a/crates/libcalibre/src/queries/authors.rs
+++ b/crates/libcalibre/src/queries/authors.rs
@@ -69,6 +69,28 @@ pub(crate) fn all(conn: &mut SqliteConnection) -> Result<Vec<Author>, CalibreErr
         .map_err(CalibreError::from)
 }
 
+/// Linked-book count per author, in one GROUP BY pass over
+/// `books_authors_link`. Authors with no linked books are absent from the
+/// map (their count is 0).
+pub(crate) fn book_counts(
+    conn: &mut SqliteConnection,
+) -> Result<HashMap<AuthorId, i64>, CalibreError> {
+    use diesel::dsl::count_star;
+
+    use crate::schema::books_authors_link::dsl::*;
+
+    let rows: Vec<(i32, i64)> = books_authors_link
+        .group_by(author)
+        .select((author, count_star()))
+        .load(conn)
+        .map_err(CalibreError::from)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(author_id, book_count)| (AuthorId(author_id), book_count))
+        .collect())
+}
+
 pub(crate) fn create(
     conn: &mut SqliteConnection,
     new_author: NewAuthor,

--- a/crates/libcalibre/tests/authors_api_test.rs
+++ b/crates/libcalibre/tests/authors_api_test.rs
@@ -154,3 +154,53 @@ fn test_delete_author_with_books_fails() {
     let result = lib.remove_author(author.id);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_author_book_counts_empty_library() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let counts = lib.author_book_counts().unwrap();
+    assert!(counts.is_empty());
+}
+
+#[test]
+fn test_author_book_counts_groups_links_per_author() {
+    let (_temp, mut lib) = setup_with_library();
+
+    let bookless_author_id = lib
+        .add_author(AuthorAdd {
+            name: "No Books".to_string(),
+            sort: Some("Books, No".to_string()),
+            link: None,
+        })
+        .unwrap();
+
+    let book = |title: &str, author_names: Vec<&str>| BookAdd {
+        title: title.to_string(),
+        author_names: author_names.into_iter().map(String::from).collect(),
+        tags: None,
+        series: None,
+        series_index: None,
+        publisher: None,
+        publication_date: None,
+        rating: None,
+        comments: None,
+        identifiers: HashMap::new(),
+        file_paths: vec![],
+    };
+
+    lib.add_book(book("Solo Work", vec!["Author A"])).unwrap();
+    lib.add_book(book("Another Solo Work", vec!["Author A"]))
+        .unwrap();
+    lib.add_book(book("Co-Written Work", vec!["Author A", "Author B"]))
+        .unwrap();
+
+    let authors = lib.authors().unwrap();
+    let id_of = |name: &str| authors.iter().find(|a| a.name == name).unwrap().id;
+
+    let counts = lib.author_book_counts().unwrap();
+    assert_eq!(counts.get(&id_of("Author A")), Some(&3));
+    assert_eq!(counts.get(&id_of("Author B")), Some(&1));
+    // Authors with no linked books are absent, not present-with-zero.
+    assert!(!counts.contains_key(&bookless_author_id));
+}

--- a/src-tauri/src/book.rs
+++ b/src-tauri/src/book.rs
@@ -59,12 +59,20 @@ pub struct LibraryBook {
 }
 
 impl LibraryBook {
-    pub fn from_library_book(book: &libcalibre::library::Book, library_path: &str) -> Self {
+    pub fn from_library_book(
+        book: &libcalibre::library::Book,
+        library_path: &str,
+        author_book_counts: &HashMap<libcalibre::AuthorId, i64>,
+    ) -> Self {
         Self {
             id: book.id.as_i32().to_string(),
             uuid: Some(book.uuid.clone()),
             title: book.title.clone(),
-            author_list: book.authors.iter().map(LibraryAuthor::from).collect(),
+            author_list: book
+                .authors
+                .iter()
+                .map(|author| LibraryAuthor::from_author(author, author_book_counts))
+                .collect(),
             tag_list: book.tags.clone(),
             sortable_title: book.sortable_title.clone(),
             identifier_list: book.identifiers.iter().map(Identifier::from).collect(),
@@ -97,6 +105,11 @@ pub struct LibraryAuthor {
     pub id: String,
     pub name: String,
     pub sortable_name: String,
+    /// Number of books in the library linked to this author, from
+    /// `Library::author_book_counts` (one GROUP BY pass over
+    /// `books_authors_link`). The Authors page renders this directly
+    /// instead of deriving counts from the whole book list.
+    pub book_count: u32,
 }
 
 #[derive(Serialize, Deserialize, specta::Type)]

--- a/src-tauri/src/libs/calibre/author.rs
+++ b/src-tauri/src/libs/calibre/author.rs
@@ -1,13 +1,26 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::book::LibraryAuthor;
 
-impl From<&libcalibre::library::Author> for LibraryAuthor {
-    fn from(author: &libcalibre::library::Author) -> Self {
+impl LibraryAuthor {
+    /// Build the DTO from a hydrated author plus the library-wide
+    /// `Library::author_book_counts` map (authors absent from the map have
+    /// no linked books).
+    pub fn from_author(
+        author: &libcalibre::library::Author,
+        book_counts: &HashMap<libcalibre::AuthorId, i64>,
+    ) -> Self {
         LibraryAuthor {
             id: author.id.as_i32().to_string(),
             name: author.name.clone(),
             sortable_name: author.sort.clone(),
+            book_count: book_counts
+                .get(&author.id)
+                .copied()
+                .map(|count| u32::try_from(count).unwrap_or(u32::MAX))
+                .unwrap_or(0),
         }
     }
 }

--- a/src-tauri/src/libs/calibre/book.rs
+++ b/src-tauri/src/libs/calibre/book.rs
@@ -1,14 +1,21 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
-use libcalibre::Library;
+use libcalibre::{AuthorId, Library};
 
 use crate::{
     book::{LibraryBook, LocalOrRemote, LocalOrRemoteUrl},
     libs::util,
 };
 
-/// Generate a LocalOrRemoteUrl for the cover image of a book, if the file exists
-/// on disk.
+/// Generate a LocalOrRemoteUrl for the cover image of a book.
+///
+/// Trusts the `has_cover` flag from the books table (Calibre keeps it
+/// accurate, and our own cover writes — `Library::set_book_cover` and
+/// `Library::add_book` — set it alongside writing cover.jpg) instead of
+/// statting cover.jpg per book: at 5k books the per-book
+/// `PathBuf::exists` dominated `clb_query_list_all_books` (~90% of 340ms).
+/// If the flag is stale (file deleted behind Calibre's back) the URL
+/// dangles and the frontend's cover `onerror` fallback takes over.
 fn book_cover_image(
     library_root: &str,
     book: &libcalibre::library::Book,
@@ -19,22 +26,21 @@ fn book_cover_image(
 
     let cover_relative_path = format!("{}/cover.jpg", &book.book_dir_path);
     let cover_image_path = PathBuf::from(library_root).join(&cover_relative_path);
+    let url = util::path_to_asset_url(&cover_image_path);
 
-    if cover_image_path.exists() {
-        let url = util::path_to_asset_url(&cover_image_path);
-
-        Some(LocalOrRemoteUrl {
-            kind: LocalOrRemote::Local,
-            local_path: Some(cover_image_path),
-            url,
-        })
-    } else {
-        None
-    }
+    Some(LocalOrRemoteUrl {
+        kind: LocalOrRemote::Local,
+        local_path: Some(cover_image_path),
+        url,
+    })
 }
 
-fn to_library_book(library_root: &str, book: &libcalibre::library::Book) -> LibraryBook {
-    let mut library_book = LibraryBook::from_library_book(book, library_root);
+fn to_library_book(
+    library_root: &str,
+    book: &libcalibre::library::Book,
+    author_book_counts: &HashMap<AuthorId, i64>,
+) -> LibraryBook {
+    let mut library_book = LibraryBook::from_library_book(book, library_root, author_book_counts);
     library_book.cover_image = book_cover_image(library_root, book);
     library_book
 }
@@ -44,10 +50,11 @@ pub fn list_all(
     lib: &mut Library,
 ) -> Result<Vec<LibraryBook>, libcalibre::CalibreError> {
     let results = lib.books()?;
+    let author_book_counts = lib.author_book_counts()?;
 
     Ok(results
         .iter()
-        .map(|book| to_library_book(&library_root, book))
+        .map(|book| to_library_book(&library_root, book, &author_book_counts))
         .collect())
 }
 
@@ -57,10 +64,11 @@ pub fn search(
     query: &str,
 ) -> Result<Vec<LibraryBook>, libcalibre::CalibreError> {
     let results = lib.search_books(query)?;
+    let author_book_counts = lib.author_book_counts()?;
 
     Ok(results
         .iter()
-        .map(|book| to_library_book(&library_root, book))
+        .map(|book| to_library_book(&library_root, book, &author_book_counts))
         .collect())
 }
 
@@ -70,12 +78,58 @@ pub fn query_page(
     query: libcalibre::BookQuery,
 ) -> Result<(Vec<LibraryBook>, i64), libcalibre::CalibreError> {
     let page = lib.query_books(query)?;
+    let author_book_counts = lib.author_book_counts()?;
 
     Ok((
         page.items
             .iter()
-            .map(|book| to_library_book(&library_root, book))
+            .map(|book| to_library_book(&library_root, book, &author_book_counts))
             .collect(),
         page.total,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_book(has_cover: bool) -> libcalibre::library::Book {
+        libcalibre::library::Book {
+            id: libcalibre::BookId::from(1),
+            uuid: "test-uuid".to_string(),
+            title: "Title".to_string(),
+            sortable_title: None,
+            authors: vec![],
+            tags: vec![],
+            series: None,
+            series_index: None,
+            description: None,
+            identifiers: vec![],
+            has_cover,
+            is_read: false,
+            files: vec![],
+            created_at: chrono::DateTime::UNIX_EPOCH.naive_utc(),
+            updated_at: chrono::DateTime::UNIX_EPOCH.naive_utc(),
+            book_dir_path: "Author/Title (1)".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_cover_flag_yields_no_cover_url() {
+        assert!(book_cover_image("/library", &test_book(false)).is_none());
+    }
+
+    /// `has_cover` is trusted without statting cover.jpg (the per-book
+    /// `PathBuf::exists` dominated list-all at 5k books). A stale flag
+    /// yields a dangling URL, which the frontend's onerror fallback absorbs.
+    #[test]
+    fn has_cover_flag_trusted_without_filesystem_check() {
+        let cover = book_cover_image("/definitely/not/a/real/library", &test_book(true))
+            .expect("has_cover implies a cover URL");
+        assert!(matches!(cover.kind, LocalOrRemote::Local));
+        let path = cover.local_path.expect("local cover keeps its path");
+        assert!(path.ends_with("cover.jpg"));
+        assert!(!path.exists());
+        assert!(cover.url.contains("cover.jpg"));
+    }
 }

--- a/src-tauri/src/libs/calibre/command.rs
+++ b/src-tauri/src/libs/calibre/command.rs
@@ -200,6 +200,9 @@ pub fn clb_cmd_create_authors(
     new_authors: Vec<NewAuthor>,
 ) -> Result<Vec<LibraryAuthor>, String> {
     state.with_library(|lib| {
+        // Freshly created authors have no linked books yet, so an empty
+        // counts map is exact (from_author defaults missing entries to 0).
+        let no_book_counts = std::collections::HashMap::new();
         let mut created = Vec::new();
         for author in &new_authors {
             let author_add = libcalibre::AuthorAdd {
@@ -209,7 +212,7 @@ pub fn clb_cmd_create_authors(
             };
             let author_id = lib.add_author(author_add).map_err(|e| e.to_string())?;
             let library_author = lib.get_author(author_id).map_err(|e| e.to_string())?;
-            created.push(LibraryAuthor::from(&library_author));
+            created.push(LibraryAuthor::from_author(&library_author, &no_book_counts));
         }
         Ok(created)
     })?

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -151,8 +151,13 @@ pub fn clb_query_list_all_authors(
 ) -> Result<Vec<LibraryAuthor>, String> {
     state
         .with_library(|lib| {
-            lib.authors()
-                .map(|author_list| author_list.iter().map(LibraryAuthor::from).collect())
+            let book_counts = lib.author_book_counts()?;
+            lib.authors().map(|author_list| {
+                author_list
+                    .iter()
+                    .map(|author| LibraryAuthor::from_author(author, &book_counts))
+                    .collect()
+            })
         })
         .and_then(|result| result.map_err(|e| format!("Failed to list authors: {}", e)))
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -304,7 +304,14 @@ path: string; publication_date: string | null;
 file_contains_cover: boolean }
 export type ImportableBookType = "Epub" | "Pdf" | "Mobi" | "Text"
 export type ImportableFile = { path: string }
-export type LibraryAuthor = { id: string; name: string; sortable_name: string }
+export type LibraryAuthor = { id: string; name: string; sortable_name: string;
+/**
+ * Number of books in the library linked to this author, from
+ * `Library::author_book_counts` (one GROUP BY pass over
+ * `books_authors_link`). The Authors page renders this directly
+ * instead of deriving counts from the whole book list.
+ */
+book_count: number }
 export type LibraryBook = { id: string; uuid: string | null; title: string; author_list: LibraryAuthor[]; tag_list: string[]; sortable_title: string | null; file_list: BookFile[]; cover_image: LocalOrRemoteUrl | null; identifier_list: Identifier[]; description: string | null; is_read: boolean; series: string | null; series_index: number | null }
 export type LibraryBookPage = { items: LibraryBook[];
 /**

--- a/src/components/molecules/AddBookForm.stories.tsx
+++ b/src/components/molecules/AddBookForm.stories.tsx
@@ -26,11 +26,13 @@ const AUTHORS: LibraryAuthor[] = [
 		name: "Robert Pattison",
 		sortable_name: "Pattison, Robert",
 		id: "gid/author/1234",
+		book_count: 2,
 	},
 	{
 		name: "Frank Herbert",
 		sortable_name: "Herbert, Frank",
 		id: "gid/author/4321",
+		book_count: 6,
 	},
 ];
 

--- a/src/components/pages/Authors.tsx
+++ b/src/components/pages/Authors.tsx
@@ -1,15 +1,17 @@
 import { Link } from "@tanstack/react-router";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import clsx from "clsx";
 import {
 	type CSSProperties,
 	type FormEvent,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useRef,
 	useState,
 } from "react";
 
-import type { AuthorUpdate, LibraryAuthor, LibraryBook } from "@/bindings";
+import type { AuthorUpdate, LibraryAuthor } from "@/bindings";
 import { AuthorFilterControls } from "@/components/organisms/AuthorFilterControls";
 import {
 	AlertDialog,
@@ -21,7 +23,6 @@ import {
 } from "@/components/ui";
 import { useAuthorFilters } from "@/lib/hooks/use-author-filters";
 import {
-	useAllBooks,
 	useAuthors,
 	useAuthorsLoading,
 	useLibraryActions,
@@ -41,13 +42,26 @@ const AUTHOR_GRID: CSSProperties = {
 	columnGap: 16,
 };
 
+/** Single-line row: 40px min-height (.ctd-author-row) + 1px bottom border. */
+const ESTIMATED_ROW_HEIGHT = 41;
+const OVERSCAN_ROWS = 10;
+
+/**
+ * Nearest scrollable ancestor — the app's shared scroll region
+ * (root.module.css .content), which the sticky header/footer rows already
+ * pin to. The virtualizer windows author rows against it.
+ */
+const findScrollParent = (element: HTMLElement): HTMLElement | null => {
+	for (let node = element.parentElement; node; node = node.parentElement) {
+		const { overflowY } = getComputedStyle(node);
+		if (overflowY === "auto" || overflowY === "scroll") return node;
+	}
+	return null;
+};
+
 export const Authors = () => {
 	const authors = useAuthors();
 	const loadingAuthors = useAuthorsLoading();
-	// Whole-library list (lazy): per-author book counts and the
-	// "authors without books" filter need every book↔author link, and no
-	// targeted per-author count query exists. See LibraryActions.loadBooks.
-	const { books, loading: loadingBooks } = useAllBooks();
 	const actions = useLibraryActions();
 
 	const {
@@ -56,7 +70,7 @@ export const Authors = () => {
 		setSortOrder,
 		setShowOnlyAuthorsWithoutBooks,
 		filteredAuthors,
-	} = useAuthorFilters(authors, books);
+	} = useAuthorFilters(authors);
 
 	const [editSheetOpened, setEditSheetOpened] = useState(false);
 	const [deleteDialogOpened, setDeleteDialogOpened] = useState(false);
@@ -113,7 +127,7 @@ export const Authors = () => {
 		}
 	}, [actions, authorToDelete]);
 
-	if (loadingAuthors || loadingBooks) {
+	if (loadingAuthors) {
 		return null;
 	}
 
@@ -165,17 +179,11 @@ export const Authors = () => {
 				<span />
 			</div>
 
-			<div className={styles.rows}>
-				{filteredAuthors?.map((author) => (
-					<AuthorRow
-						author={author}
-						books={books}
-						key={author.id}
-						onEditAuthor={onOpenEditAuthorSheet}
-						onDeleteAuthor={onOpenDeleteAuthorDialog}
-					/>
-				))}
-			</div>
+			<AuthorRows
+				authors={filteredAuthors}
+				onEditAuthor={onOpenEditAuthorSheet}
+				onDeleteAuthor={onOpenDeleteAuthorDialog}
+			/>
 
 			<div className={styles.footer}>
 				<span className={styles.footerText}>
@@ -286,21 +294,98 @@ const EditAuthorSheet = ({
 	);
 };
 
+/**
+ * The author list, windowed with @tanstack/react-virtual (same pattern as
+ * BookGrid): only rows near the viewport mount. The page itself does not
+ * scroll — rows window against the app's shared scroll region, so the
+ * sticky header/footer keep pinning exactly as before.
+ */
+const AuthorRows = ({
+	authors,
+	onEditAuthor,
+	onDeleteAuthor,
+}: {
+	authors: LibraryAuthor[];
+	onEditAuthor: (authorId: string) => void;
+	onDeleteAuthor: (authorId: string) => void;
+}) => {
+	const rowsRef = useRef<HTMLDivElement>(null);
+	const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
+	// Distance from the scroll region's content top to the first row (the
+	// filter bar + sticky column header above the list).
+	const [scrollMargin, setScrollMargin] = useState(0);
+
+	useLayoutEffect(() => {
+		const rows = rowsRef.current;
+		if (!rows) return;
+		const scrollParent = findScrollParent(rows);
+		setScrollElement(scrollParent);
+		if (!scrollParent) return;
+
+		const measure = () => {
+			setScrollMargin(
+				rows.getBoundingClientRect().top -
+					scrollParent.getBoundingClientRect().top +
+					scrollParent.scrollTop,
+			);
+		};
+		measure();
+		const observer = new ResizeObserver(measure);
+		observer.observe(scrollParent);
+		return () => observer.disconnect();
+	}, []);
+
+	const virtualizer = useVirtualizer({
+		count: authors.length,
+		getScrollElement: () => scrollElement,
+		estimateSize: () => ESTIMATED_ROW_HEIGHT,
+		overscan: OVERSCAN_ROWS,
+		scrollMargin,
+	});
+
+	return (
+		<div
+			ref={rowsRef}
+			className={styles.rows}
+			style={{ position: "relative", height: virtualizer.getTotalSize() }}
+		>
+			{virtualizer.getVirtualItems().map((virtualRow) => {
+				const author = authors[virtualRow.index];
+				if (author === undefined) return null;
+				return (
+					<div
+						key={author.id}
+						ref={virtualizer.measureElement}
+						data-index={virtualRow.index}
+						style={{
+							position: "absolute",
+							top: 0,
+							left: 0,
+							width: "100%",
+							transform: `translateY(${virtualRow.start - scrollMargin}px)`,
+						}}
+					>
+						<AuthorRow
+							author={author}
+							onEditAuthor={onEditAuthor}
+							onDeleteAuthor={onDeleteAuthor}
+						/>
+					</div>
+				);
+			})}
+		</div>
+	);
+};
+
 const AuthorRow = ({
 	author,
-	books,
 	onEditAuthor,
 	onDeleteAuthor,
 }: {
 	author: LibraryAuthor;
-	books: LibraryBook[];
 	onEditAuthor: (authorId: string) => void;
 	onDeleteAuthor: (authorId: string) => void;
 }) => {
-	const numBooksByAuthor = books.filter((book) =>
-		new Set(book.author_list.map((a) => a.id)).has(author.id),
-	).length;
-
 	return (
 		// The whole row links to the library filtered by this author. The hover
 		// background, 40px min-height, and the overlay-link positioning live in
@@ -338,7 +423,7 @@ const AuthorRow = ({
 				search={{ author_id: author.id }}
 				className={styles.countLink}
 			>
-				{numBooksByAuthor}
+				{author.book_count}
 			</Link>
 
 			<div className={styles.actions}>
@@ -349,7 +434,7 @@ const AuthorRow = ({
 				>
 					<F7Pencil />
 				</IconButton>
-				{numBooksByAuthor === 0 ? (
+				{author.book_count === 0 ? (
 					<IconButton
 						className={clsx(styles.actionIcon, styles.dangerIcon)}
 						aria-label={`Delete ${author.name}`}

--- a/src/components/pages/Books.stories.tsx
+++ b/src/components/pages/Books.stories.tsx
@@ -13,11 +13,13 @@ const Bugliacci: LibraryAuthor = {
 	id: "0000004JFG0DKZV4DGR66BKW9D",
 	name: "Bugliacci",
 	sortable_name: "Bugliacci",
+	book_count: 1,
 };
 const Gregor_Samsa: LibraryAuthor = {
 	id: "0000004JFGJFYH5BDPJSENX6C8",
 	name: "Gregor Samsa",
 	sortable_name: "Samsa, Gregor",
+	book_count: 1,
 };
 
 const MOCK_BOOK: LibraryBook = {

--- a/src/lib/hooks/use-author-filters.ts
+++ b/src/lib/hooks/use-author-filters.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { LibraryAuthor, LibraryBook } from "@/bindings";
+import type { LibraryAuthor } from "@/bindings";
 import { sortAuthors } from "@/lib/domain/author";
 
 export const AuthorSortOrder = {
@@ -42,7 +42,6 @@ export interface UseAuthorFiltersReturn {
 
 export const useAuthorFilters = (
 	authors: LibraryAuthor[],
-	books: LibraryBook[],
 ): UseAuthorFiltersReturn => {
 	const [searchTerm, setSearchTerm] = useState("");
 	const [sortOrder, setSortOrder] = useState<AuthorSortOrderValue>(
@@ -64,10 +63,7 @@ export const useAuthorFilters = (
 		}
 
 		if (showOnlyAuthorsWithoutBooks) {
-			const authorIdsWithBooks = new Set(
-				books.flatMap((book) => book.author_list.map((a) => a.id)),
-			);
-			result = result.filter((author) => !authorIdsWithBooks.has(author.id));
+			result = result.filter((author) => author.book_count === 0);
 		}
 
 		result.sort(sortAuthors);
@@ -77,7 +73,7 @@ export const useAuthorFilters = (
 		}
 
 		return result;
-	}, [authors, books, searchTerm, sortOrder, showOnlyAuthorsWithoutBooks]);
+	}, [authors, searchTerm, sortOrder, showOnlyAuthorsWithoutBooks]);
 
 	return {
 		filters: {

--- a/src/stores/library/store.ts
+++ b/src/stores/library/store.ts
@@ -43,11 +43,10 @@ interface LibraryActions {
 	 *
 	 * Kept (and loaded lazily, see `useAllBooks`) for the consumers that
 	 * genuinely need whole-library data and have no targeted query:
-	 * - the Authors page: per-author book counts and the "authors without
-	 *   books" filter need every book↔author link;
 	 * - the book detail route: the tag autocomplete needs the full tag
 	 *   vocabulary (and there is no fetch-one-book command).
-	 * The cover grid does NOT use this; it pages via `ensureBookRange`.
+	 * The Authors page no longer uses this (per-author book counts ride on
+	 * the authors payload); the cover grid pages via `ensureBookRange`.
 	 */
 	loadBooks: () => Promise<void>;
 	loadAuthors: () => Promise<void>;
@@ -335,9 +334,11 @@ export const useLibraryStore = create<LibraryStoreState>((set, get) => {
 					bookCache: invalidateBookCache(state.bookCache),
 					allBooksGeneration: state.allBooksGeneration + 1,
 				}));
-				// Mutations can rename/create series and change the library
-				// size; refresh both in the background.
+				// Mutations can rename/create series, change the library size,
+				// and change per-author book counts (which ride on the authors
+				// payload); refresh all three in the background.
 				void get().actions.loadSeries();
+				void get().actions.loadAuthors();
 				void refreshLibraryTotal();
 			},
 

--- a/src/test/factories/library-author.ts
+++ b/src/test/factories/library-author.ts
@@ -19,6 +19,7 @@ export const LibraryAuthorFactory = (
 		id: faker.string.uuid(),
 		name,
 		sortable_name,
+		book_count: faker.number.int({ min: 0, max: 30 }),
 		...opts,
 	};
 };


### PR DESCRIPTION
Three measurement-backed fixes from profiling against a 5,000-book / 617-author stress library.

## Fix 1 — stop statting cover.jpg per book (`has_cover` is trusted)

`clb_query_list_all_books` measured **340ms** at 5k books vs **~33ms** of backend hydration; ~90% was `book_cover_image` in src-tauri doing a `PathBuf::exists` per book. The books table maintains a `has_cover` flag — Calibre keeps it accurate, and our own cover writes set it too (verified: `Library::set_book_cover` sets `has_cover = true` in the same transaction as the file write, and `Library::add_book` sets it after extracting a cover). Cover URL construction now trusts the flag, for `clb_query_list_all_books`, `clb_query_search_books`, and `clb_query_books` alike (shared `to_library_book` path).

**Behavior note:** when `has_cover = true` but cover.jpg is genuinely missing (file deleted behind Calibre's back), the backend now emits a dangling asset URL instead of `None`. The cover `onError` fallback that landed in #121 absorbs this — the grid degrades to the no-cover placeholder instead of a broken image.

`LibraryBook` shape is unchanged; bindings.ts untouched for this fix.

## Fix 2 — Authors page counts come from one GROUP BY, `useAllBooks` dropped

Warm render of the Authors page measured **~480ms** for 617 rows: each row's count scanned all 5,000 books (O(authors×books)), and the page pulled the whole library via `useAllBooks` just for counts + the "authors without books" filter — also triggering the 340ms list-all above on page load.

Instead of memoizing a count map over the books array, the counts moved to the backend: new `Library::author_book_counts()` (single GROUP BY over `books_authors_link`, mirroring the `list_series`/`SeriesSummary` precedent), and `LibraryAuthor` gains `book_count: u32`, populated everywhere the DTO is built. The Authors page **no longer uses `useAllBooks` at all** — counts and the authors-without-books filter read `author.book_count`. `invalidateBooks` now also reloads authors in the background so counts stay fresh after book mutations (previously the page got this for free from the stale-books reload).

bindings.ts hand-edited in specta style (field order matches the Rust struct); all other `LibraryAuthor` consumers still compile.

Release-mode bench against the stress library (`bench_library_queries`, 7 runs after 2 warmup):

| Scenario | min | median | max |
| --- | ---: | ---: | ---: |
| `authors()` (617 rows) | 0.13 | 0.14 | 0.15 |
| `author_book_counts()` (617 authors / 5,000 links) | 0.25 | 0.25 | 0.28 |

i.e. the whole authors payload incl. counts is ~0.4ms of backend work, replacing a 340ms list-all trigger plus the O(authors×books) render scan.

## Fix 3 — virtualize the author list

617 unvirtualized rows → windowed with `@tanstack/react-virtual` (already a dependency; same pattern as BookGrid). Rows virtualize against the app's shared scroll region (`root.module.css` `.content`), so the page's visual layout, the sticky filter bar / column header / footer, and the whole-row overlay-link behavior are unchanged; only rows near the viewport mount.

## Tests

- libcalibre: `author_book_counts` integration tests (empty library; per-author grouping incl. co-authored books; bookless authors absent from the map).
- src-tauri: unit tests for `book_cover_image` (no cover ⇒ no URL; `has_cover` trusted without a filesystem check).
- Frontend: factories/stories updated for `book_count`; full vitest suite green.

## Gates

`cargo fmt --all` ✓ · `cargo clippy --workspace` ✓ (16 pre-existing warnings, none new) · `cargo test --workspace` ✓ (15/15 suites) · `bunx tsc --noEmit` ✓ · `bunx biome lint src/` ✓ (2 pre-existing warnings in untouched files) · `bunx vitest run` ✓ (172 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
