### PR TITLE
perf: scope edit-route data; retire whole-library fetch

### DIFF
--- a/crates/libcalibre/src/lib.rs
+++ b/crates/libcalibre/src/lib.rs
@@ -20,6 +20,7 @@ pub use error::CalibreError;
 pub use library::{
     Author as LibraryAuthor, AuthorAdd, AuthorUpdate, Book as LibraryBook, BookAdd, BookFileInfo,
     BookIdentifier, BookPage, BookQuery, BookSortOrder, BookUpdate, Library, SeriesSummary,
+    TagSummary,
 };
 pub use types::{AuthorId, BookFileId, BookId};
 

--- a/crates/libcalibre/src/library.rs
+++ b/crates/libcalibre/src/library.rs
@@ -183,6 +183,14 @@ pub struct SeriesSummary {
     pub book_count: i64,
 }
 
+/// One tag in the library. Returned by [`Library::list_tags`]; the full
+/// vocabulary feeds tag autocomplete in clients.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TagSummary {
+    pub id: i32,
+    pub name: String,
+}
+
 impl Library {
     pub fn new(db_path: ValidDbPath) -> Result<Self, CalibreError> {
         let conn = establish_connection(&db_path.database_path)
@@ -778,6 +786,12 @@ impl Library {
     /// by name. The returned ids feed [`BookQuery::series_id`].
     pub fn list_series(&mut self) -> Result<Vec<SeriesSummary>, CalibreError> {
         crate::queries::series::list_with_book_counts(&mut self.conn)
+    }
+
+    /// List every tag in the library (the whole vocabulary, including tags
+    /// no longer linked to any book), sorted case-insensitively by name.
+    pub fn list_tags(&mut self) -> Result<Vec<TagSummary>, CalibreError> {
+        crate::queries::tags::list_all(&mut self.conn)
     }
 
     pub fn search_books(&mut self, query: &str) -> Result<Vec<Book>, CalibreError> {

--- a/crates/libcalibre/src/queries/tags.rs
+++ b/crates/libcalibre/src/queries/tags.rs
@@ -6,8 +6,28 @@ use diesel::sql_types::{Integer, Text};
 use diesel::{QueryDsl, RunQueryDsl, SqliteConnection};
 
 use crate::entities::tag::NewTag;
+use crate::library::TagSummary;
 use crate::types::BookId;
 use crate::{CalibreError, Tag};
+
+/// Every tag in the library, sorted case-insensitively by name (with the
+/// raw name as a stable tiebreak, matching [`find_for_book`]).
+pub(crate) fn list_all(conn: &mut SqliteConnection) -> Result<Vec<TagSummary>, CalibreError> {
+    use crate::schema::tags::dsl::*;
+
+    tags.select(Tag::as_select())
+        .order_by(diesel::dsl::sql::<Text>("LOWER(name), name"))
+        .load(conn)
+        .map(|rows: Vec<Tag>| {
+            rows.into_iter()
+                .map(|tag| TagSummary {
+                    id: tag.id,
+                    name: tag.name,
+                })
+                .collect()
+        })
+        .map_err(CalibreError::from)
+}
 
 pub(crate) fn find_by_name_case_insensitive(
     conn: &mut SqliteConnection,

--- a/crates/libcalibre/tests/query_test.rs
+++ b/crates/libcalibre/tests/query_test.rs
@@ -532,6 +532,48 @@ fn test_page_items_are_hydrated() {
 }
 
 // =============================================================================
+// Tag listing
+// =============================================================================
+
+#[test]
+fn test_list_tags_returns_deduped_vocabulary_sorted_by_name() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(BookAdd {
+        tags: Some(vec!["fantasy".to_string(), "Adventure".to_string()]),
+        ..book("A Wizard of Earthsea", &["Ursula K. Le Guin"])
+    })
+    .unwrap();
+    // "FANTASY" matches the existing "fantasy" case-insensitively, so the
+    // vocabulary keeps the first spelling instead of growing a duplicate.
+    lib.add_book(BookAdd {
+        tags: Some(vec!["FANTASY".to_string(), "banned".to_string()]),
+        ..book("The Tombs of Atuan", &["Ursula K. Le Guin"])
+    })
+    .unwrap();
+    lib.add_book(book("Untagged", &["Nobody"])).unwrap();
+
+    let tags = lib.list_tags().unwrap();
+    let names: Vec<&str> = tags.iter().map(|t| t.name.as_str()).collect();
+    // Case-insensitive name sort: Adventure < banned < fantasy.
+    assert_eq!(names, ["Adventure", "banned", "fantasy"]);
+
+    // Ids are the real `tags` rows, each one distinct.
+    let mut ids: Vec<i32> = tags.iter().map(|t| t.id).collect();
+    ids.dedup();
+    assert_eq!(ids.len(), 3);
+}
+
+#[test]
+fn test_list_tags_empty_library() {
+    let (_temp, mut lib) = setup_with_library();
+
+    lib.add_book(book("No Tags Here", &[])).unwrap();
+
+    assert!(lib.list_tags().unwrap().is_empty());
+}
+
+// =============================================================================
 // Series listing
 // =============================================================================
 

--- a/src-tauri/src/libs/calibre/book.rs
+++ b/src-tauri/src/libs/calibre/book.rs
@@ -13,7 +13,8 @@ use crate::{
 /// accurate, and our own cover writes — `Library::set_book_cover` and
 /// `Library::add_book` — set it alongside writing cover.jpg) instead of
 /// statting cover.jpg per book: at 5k books the per-book
-/// `PathBuf::exists` dominated `clb_query_list_all_books` (~90% of 340ms).
+/// `PathBuf::exists` dominated the (since-retired) whole-library list
+/// command (~90% of 340ms).
 /// If the flag is stale (file deleted behind Calibre's back) the URL
 /// dangles and the frontend's cover `onerror` fallback takes over.
 fn book_cover_image(
@@ -46,27 +47,15 @@ fn to_library_book(
 }
 
 /// One book, hydrated exactly like a `query_page` item (authors, tags,
-/// series, identifiers, files, read state, cover URL).
+/// series, identifiers, files, read state, cover URL, author book counts).
 pub fn get_one(
     library_root: String,
     lib: &mut Library,
     book_id: libcalibre::BookId,
 ) -> Result<LibraryBook, libcalibre::CalibreError> {
     let book = lib.get_book(book_id)?;
-    Ok(to_library_book(&library_root, &book))
-}
-
-pub fn list_all(
-    library_root: String,
-    lib: &mut Library,
-) -> Result<Vec<LibraryBook>, libcalibre::CalibreError> {
-    let results = lib.books()?;
     let author_book_counts = lib.author_book_counts()?;
-
-    Ok(results
-        .iter()
-        .map(|book| to_library_book(&library_root, book, &author_book_counts))
-        .collect())
+    Ok(to_library_book(&library_root, &book, &author_book_counts))
 }
 
 pub fn search(

--- a/src-tauri/src/libs/calibre/book.rs
+++ b/src-tauri/src/libs/calibre/book.rs
@@ -45,6 +45,17 @@ fn to_library_book(
     library_book
 }
 
+/// One book, hydrated exactly like a `query_page` item (authors, tags,
+/// series, identifiers, files, read state, cover URL).
+pub fn get_one(
+    library_root: String,
+    lib: &mut Library,
+    book_id: libcalibre::BookId,
+) -> Result<LibraryBook, libcalibre::CalibreError> {
+    let book = lib.get_book(book_id)?;
+    Ok(to_library_book(&library_root, &book))
+}
+
 pub fn list_all(
     library_root: String,
     lib: &mut Library,

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -116,6 +116,26 @@ pub fn clb_query_books(
     })
 }
 
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_get_book(
+    state: tauri::State<CitadelState>,
+    book_id: String,
+) -> Result<LibraryBook, String> {
+    let library_root = state
+        .get_library_path()
+        .ok_or("No library loaded".to_string())?;
+
+    let book_id_int = book_id
+        .parse::<i32>()
+        .map_err(|e| format!("Invalid book id '{book_id}': {e}"))?;
+
+    let book = state.with_library(|lib| {
+        book::get_one(library_root, lib, libcalibre::BookId::from(book_id_int))
+    })?;
+    book.map_err(|e| e.to_string())
+}
+
 /// One series in the library. `id` is what [`LibraryBookQuery::series_id`]
 /// filters on; the frontend otherwise only ever sees series names.
 #[derive(Serialize, Deserialize, specta::Type, Clone)]
@@ -140,6 +160,29 @@ pub fn clb_query_list_series(
             id: series.id,
             name: series.name,
             book_count: u32::try_from(series.book_count).unwrap_or(u32::MAX),
+        })
+        .collect())
+}
+
+/// One tag in the library; `name` is what the tag autocomplete suggests.
+#[derive(Serialize, Deserialize, specta::Type, Clone)]
+pub struct LibraryTag {
+    pub id: i32,
+    pub name: String,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_list_tags(state: tauri::State<CitadelState>) -> Result<Vec<LibraryTag>, String> {
+    let tags = state
+        .with_library(|lib| lib.list_tags())?
+        .map_err(|e| e.to_string())?;
+
+    Ok(tags
+        .into_iter()
+        .map(|tag| LibraryTag {
+            id: tag.id,
+            name: tag.name,
         })
         .collect())
 }

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -13,19 +13,6 @@ use super::ImportableFile;
 
 #[tauri::command]
 #[specta::specta]
-pub fn clb_query_list_all_books(
-    state: tauri::State<CitadelState>,
-) -> Result<Vec<LibraryBook>, String> {
-    let library_root = state
-        .get_library_path()
-        .ok_or("No library loaded".to_string())?;
-
-    let books = state.with_library(|lib| book::list_all(library_root, lib))?;
-    books.map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-#[specta::specta]
 pub fn clb_query_search_books(
     state: tauri::State<CitadelState>,
     query: String,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,7 +25,6 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::query::clb_query_is_path_valid_library,
         calibre::command::clb_cmd_create_library,
         // Book query commands
-        calibre::query::clb_query_list_all_books,
         calibre::query::clb_query_search_books,
         calibre::query::clb_query_books,
         calibre::query::clb_query_get_book,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -28,11 +28,14 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::query::clb_query_list_all_books,
         calibre::query::clb_query_search_books,
         calibre::query::clb_query_books,
+        calibre::query::clb_query_get_book,
         calibre::query::clb_query_is_file_importable,
         calibre::query::clb_query_importable_file_metadata,
         calibre::query::clb_query_list_all_filetypes,
         // Series query commands
         calibre::query::clb_query_list_series,
+        // Tag query commands
+        calibre::query::clb_query_list_tags,
         // Book manipulation commands
         calibre::command::clb_cmd_create_book,
         calibre::command::clb_cmd_update_book,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -48,6 +48,14 @@ async clbQueryBooks(query: LibraryBookQuery) : Promise<Result<LibraryBookPage, s
     else return { status: "error", error: e  as any };
 }
 },
+async clbQueryGetBook(bookId: string) : Promise<Result<LibraryBook, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_get_book", { bookId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbQueryIsFileImportable(pathToFile: string) : Promise<ImportableFile | null> {
     return await TAURI_INVOKE("clb_query_is_file_importable", { pathToFile });
 },
@@ -60,6 +68,14 @@ async clbQueryListAllFiletypes() : Promise<([string, string])[]> {
 async clbQueryListSeries() : Promise<Result<LibrarySeries[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clb_query_list_series") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async clbQueryListTags() : Promise<Result<LibraryTag[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_list_tags") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -333,6 +349,10 @@ limit: number | null; offset: number }
  * filters on; the frontend otherwise only ever sees series names.
  */
 export type LibrarySeries = { id: number; name: string; book_count: number }
+/**
+ * One tag in the library; `name` is what the tag autocomplete suggests.
+ */
+export type LibraryTag = { id: number; name: string }
 export type LocalFile = { 
 /**
  * The absolute path to the file, including extension.

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -24,14 +24,6 @@ async clbCmdCreateLibrary(libraryRoot: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async clbQueryListAllBooks() : Promise<Result<LibraryBook[], string>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("clb_query_list_all_books") };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
 async clbQuerySearchBooks(query: string) : Promise<Result<LibraryBook[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clb_query_search_books", { query }) };

--- a/src/lib/domain/tag.test.ts
+++ b/src/lib/domain/tag.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { sortedTagNames, tagListChanged } from "./tag";
+
+describe("sortedTagNames", () => {
+	it("extracts names sorted with localeCompare", () => {
+		expect(
+			sortedTagNames([
+				{ name: "fantasy" },
+				{ name: "Adventure" },
+				{ name: "banned" },
+			]),
+		).toEqual(["Adventure", "banned", "fantasy"]);
+	});
+
+	it("keeps duplicates and handles an empty vocabulary", () => {
+		expect(sortedTagNames([])).toEqual([]);
+		expect(sortedTagNames([{ name: "a" }, { name: "a" }])).toEqual(["a", "a"]);
+	});
+});
+
+describe("tagListChanged", () => {
+	it("treats null as tags untouched", () => {
+		expect(tagListChanged(["fantasy"], null)).toBe(false);
+	});
+
+	it("ignores order", () => {
+		expect(tagListChanged(["a", "b"], ["b", "a"])).toBe(false);
+	});
+
+	it("detects added, removed, and renamed tags", () => {
+		expect(tagListChanged([], ["new"])).toBe(true);
+		expect(tagListChanged(["old"], [])).toBe(true);
+		expect(tagListChanged(["old"], ["renamed"])).toBe(true);
+	});
+
+	it("treats identical lists as unchanged", () => {
+		expect(tagListChanged([], [])).toBe(false);
+		expect(tagListChanged(["a"], ["a"])).toBe(false);
+	});
+});

--- a/src/lib/domain/tag.ts
+++ b/src/lib/domain/tag.ts
@@ -1,0 +1,24 @@
+import type { LibraryTag } from "@/bindings";
+
+/** Tag names for the tag autocomplete, locale-sorted ascending. */
+export const sortedTagNames = (tags: Pick<LibraryTag, "name">[]): string[] =>
+	tags.map((tag) => tag.name).sort((left, right) => left.localeCompare(right));
+
+/**
+ * Whether a save's `tag_list` differs from the book's current tags (order
+ * ignored). `null` means "tags untouched" in a `BookUpdate`. Used to skip
+ * re-fetching the tag vocabulary after saves that cannot have changed it.
+ */
+export const tagListChanged = (
+	current: readonly string[],
+	next: readonly string[] | null,
+): boolean => {
+	if (next === null) {
+		return false;
+	}
+	if (next.length !== current.length) {
+		return true;
+	}
+	const currentSet = new Set(current);
+	return next.some((name) => !currentSet.has(name));
+};

--- a/src/lib/hooks/use-edit-book-data.ts
+++ b/src/lib/hooks/use-edit-book-data.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState } from "react";
+
+import type { LibraryBook } from "@/bindings";
+import { sortedTagNames } from "@/lib/domain/tag";
+import { useLibraryReady, useLibraryStore } from "@/stores/library/store";
+
+export interface EditBookData {
+	/** The book being edited; null while loading or when not found. */
+	book: LibraryBook | null;
+	/** Full tag vocabulary for the tag autocomplete, locale-sorted. */
+	allTagList: string[];
+	/** True during the initial fetch for a bookId; refreshes stay quiet. */
+	loading: boolean;
+	error: string | null;
+	/**
+	 * Re-fetch only this book (after a save or identifier change). The
+	 * stale form stays on screen instead of flashing a spinner.
+	 */
+	refreshBook: () => Promise<void>;
+	/** Re-fetch the tag vocabulary (after a save that changed tags). */
+	refreshTags: () => Promise<void>;
+}
+
+/**
+ * The edit route's scoped data: exactly its own book (clb_query_get_book)
+ * and the library's tag vocabulary (clb_query_list_tags). Saves invalidate
+ * the paged grid cache through the store; this hook never triggers — and the
+ * route never pays for — a whole-library fetch.
+ */
+export const useEditBookData = (bookId: string): EditBookData => {
+	const library = useLibraryStore((state) => state.library);
+	const ready = useLibraryReady();
+
+	const [book, setBook] = useState<LibraryBook | null>(null);
+	const [allTagList, setAllTagList] = useState<string[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	const refreshBook = useCallback(async () => {
+		if (!library) return;
+		setBook(await library.getBook(bookId));
+	}, [library, bookId]);
+
+	const refreshTags = useCallback(async () => {
+		if (!library) return;
+		setAllTagList(sortedTagNames(await library.listTags()));
+	}, [library]);
+
+	useEffect(() => {
+		if (!ready || !library) return;
+
+		let cancelled = false;
+		setLoading(true);
+		setError(null);
+		// Navigating to a different book: drop the previous one immediately
+		// so its form never renders against the new id.
+		setBook(null);
+
+		void (async () => {
+			try {
+				const [nextBook, tags] = await Promise.all([
+					library.getBook(bookId),
+					library.listTags(),
+				]);
+				if (cancelled) return;
+				setBook(nextBook);
+				setAllTagList(sortedTagNames(tags));
+			} catch (fetchError) {
+				if (cancelled) return;
+				setError(
+					fetchError instanceof Error ? fetchError.message : String(fetchError),
+				);
+			} finally {
+				if (!cancelled) {
+					setLoading(false);
+				}
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ready, library, bookId]);
+
+	return { book, allTagList, loading, error, refreshBook, refreshTags };
+};

--- a/src/lib/services/library/_internal/_types.ts
+++ b/src/lib/services/library/_internal/_types.ts
@@ -23,7 +23,6 @@ export interface FileType {
 
 export interface Library {
 	createAuthors(newAuthors: NewAuthor[]): Promise<LibraryAuthor[]>;
-	listBooks(): Promise<LibraryBook[]>;
 	/**
 	 * One page of a filtered, sorted book query (the cover grid's data
 	 * source). `query.text = null` matches all books; `total` counts the

--- a/src/lib/services/library/_internal/_types.ts
+++ b/src/lib/services/library/_internal/_types.ts
@@ -8,6 +8,7 @@ import type {
 	LibraryBookPage,
 	LibraryBookQuery,
 	LibrarySeries,
+	LibraryTag,
 	NewAuthor,
 } from "@/bindings";
 
@@ -29,9 +30,16 @@ export interface Library {
 	 * filtered set ignoring paging.
 	 */
 	queryBooks(query: LibraryBookQuery): Promise<LibraryBookPage>;
+	/**
+	 * One book, hydrated exactly like a `queryBooks` page item. Rejects when
+	 * no book has the given id.
+	 */
+	getBook(bookId: LibraryBook["id"]): Promise<LibraryBook>;
 	listAuthors(): Promise<LibraryAuthor[]>;
 	/** Every series with its book count; ids feed `LibraryBookQuery.series_id`. */
 	listSeries(): Promise<LibrarySeries[]>;
+	/** The library's full tag vocabulary (feeds tag autocomplete). */
+	listTags(): Promise<LibraryTag[]>;
 	sendToDevice(
 		book: LibraryBook,
 		deviceOptions: {

--- a/src/lib/services/library/_internal/adapters/calibre.ts
+++ b/src/lib/services/library/_internal/adapters/calibre.ts
@@ -94,6 +94,27 @@ const genLocalCalibreClient = async (
 
 			return results.data;
 		},
+		getBook: async (bookId) => {
+			const result = await commands.clbQueryGetBook(bookId);
+			if (result.status === "error") {
+				throw new Error(result.error);
+			}
+
+			const book = result.data;
+			bookCoverCache.set(book.id.toString(), {
+				localPath: book.cover_image?.local_path ?? "",
+				url: book.cover_image?.url ?? "",
+			});
+			const primaryFile = book.file_list[0];
+			if (primaryFile !== undefined && "Local" in primaryFile) {
+				bookFilePath.set(book.id.toString(), {
+					localPath: primaryFile.Local.path,
+					url: undefined,
+				});
+			}
+
+			return book;
+		},
 		listAuthors: async () => {
 			const results = await commands.clbQueryListAllAuthors();
 			if (results.status === "error") {
@@ -103,6 +124,13 @@ const genLocalCalibreClient = async (
 		},
 		listSeries: async () => {
 			const results = await commands.clbQueryListSeries();
+			if (results.status === "error") {
+				throw new Error(results.error);
+			}
+			return results.data;
+		},
+		listTags: async () => {
+			const results = await commands.clbQueryListTags();
 			if (results.status === "error") {
 				throw new Error(results.error);
 			}
@@ -219,10 +247,16 @@ const genRemoteCalibreClient = async (
 		queryBooks() {
 			throw new Error("Not implemented");
 		},
+		getBook() {
+			throw new Error("Not implemented");
+		},
 		listAuthors() {
 			throw new Error("Not implemented");
 		},
 		listSeries() {
+			throw new Error("Not implemented");
+		},
+		listTags() {
 			throw new Error("Not implemented");
 		},
 		sendToDevice: () => {

--- a/src/lib/services/library/_internal/adapters/calibre.ts
+++ b/src/lib/services/library/_internal/adapters/calibre.ts
@@ -45,33 +45,6 @@ const genLocalCalibreClient = async (
 			}
 			return results.data;
 		},
-		listBooks: async () => {
-			const results = await commands.clbQueryListAllBooks();
-			if (results.status === "error") {
-				throw new Error(results.error);
-			}
-			const books = results.data;
-
-			for (const book of books) {
-				bookCoverCache.set(book.id.toString(), {
-					localPath: book.cover_image?.local_path ?? "",
-					url: book.cover_image?.url ?? "",
-				});
-				if (book.file_list[0] === undefined) {
-					return [];
-				}
-
-				const primaryFile = book.file_list[0];
-				if ("Local" in primaryFile) {
-					bookFilePath.set(book.id.toString(), {
-						localPath: primaryFile.Local.path,
-						url: undefined,
-					});
-				}
-			}
-
-			return books;
-		},
 		queryBooks: async (query: LibraryBookQuery) => {
 			const results = await commands.clbQueryBooks(query);
 			if (results.status === "error") {
@@ -216,33 +189,21 @@ const genLocalCalibreClient = async (
 };
 
 const genRemoteCalibreClient = async (
-	options: RemoteConnectionOptions,
+	_options: RemoteConnectionOptions,
 	// The interface requires this function to be async.
 	// eslint-disable-next-line @typescript-eslint/require-await
 ): Promise<Library> => {
 	// All remote clients are really Citadel clients... but for a certain kind of
 	// library. In this case, Calibre.
-	const baseUrl = options.url;
+	// `_options.url` will be the base URL once any remote method is implemented.
 
+	// Nothing populates this yet (the whole-library fetch is gone); remote
+	// cover/file lookups return undefined until a remote book fetch exists.
 	const bookCache = new Map<LibraryBook["id"], LibraryBook>();
 
 	return {
 		createAuthors() {
 			throw new Error("Not implemented");
-		},
-		listBooks: async () => {
-			const res = await fetch(`${baseUrl}/books`)
-				.then((res) => res.json() as unknown as { items: LibraryBook[] })
-				.then((res) => res.items)
-				.then((res) => {
-					return res;
-				});
-
-			for (const book of res) {
-				bookCache.set(book.id, book);
-			}
-
-			return res;
 		},
 		queryBooks() {
 			throw new Error("Not implemented");

--- a/src/routes/books.$bookId.tsx
+++ b/src/routes/books.$bookId.tsx
@@ -1,11 +1,12 @@
 import { createFileRoute, useParams } from "@tanstack/react-router";
-import { type CSSProperties, useCallback, useMemo } from "react";
+import { type CSSProperties, useCallback } from "react";
 import type { BookUpdate, NewAuthor } from "@/bindings";
 import { BookPage } from "@/components/pages/EditBook";
 import { Spinner } from "@/components/ui";
+import { tagListChanged } from "@/lib/domain/tag";
+import { useEditBookData } from "@/lib/hooks/use-edit-book-data";
 import {
 	LibraryState,
-	useAllBooks,
 	useAuthors,
 	useLibraryActions,
 	useLibraryState,
@@ -23,33 +24,28 @@ const EditBookRoute = () => {
 	const state = useLibraryState();
 	const actions = useLibraryActions();
 
-	// Whole-library list (lazy): the tag autocomplete needs the full tag
-	// vocabulary and there is no fetch-one-book or list-tags command, so
-	// this route stays on clb_query_list_all_books (one fetch on entry, off
-	// the hot path). See LibraryActions.loadBooks.
-	const { books, loading: loadingBooks } = useAllBooks();
+	// Scoped fetches: this route loads exactly its own book and the tag
+	// vocabulary (for the tag autocomplete) — never the whole library.
+	const { book, allTagList, loading, error, refreshBook, refreshTags } =
+		useEditBookData(bookId);
 	const allAuthorList = useAuthors();
-	const allTagList = useMemo(
-		() =>
-			Array.from(
-				new Set(books.flatMap((candidate) => candidate.tag_list)),
-			).sort((left, right) => left.localeCompare(right)),
-		[books],
-	);
-
-	// Find the book from the store
-	const book = useMemo(
-		() => books.find((b) => b.id === bookId),
-		[books, bookId],
-	);
 
 	const onSave = useCallback(
 		async (bookUpdate: BookUpdate) => {
-			if (actions) {
-				await actions.updateBook(bookId, bookUpdate);
+			if (!actions) return;
+			const tagsChanged = tagListChanged(
+				book?.tag_list ?? [],
+				bookUpdate.tag_list,
+			);
+			// updateBook drops the paged grid cache (visible pages refetch
+			// lazily); this route then re-fetches only its own data.
+			await actions.updateBook(bookId, bookUpdate);
+			await refreshBook();
+			if (tagsChanged) {
+				await refreshTags();
 			}
 		},
-		[actions, bookId],
+		[actions, bookId, book, refreshBook, refreshTags],
 	);
 
 	const onCreateAuthor = useCallback(
@@ -73,33 +69,35 @@ const EditBookRoute = () => {
 			label: string,
 			value: string,
 		) => {
-			if (actions) {
-				await actions.upsertBookIdentifier(bookId, identifierId, label, value);
-			}
+			if (!actions) return;
+			await actions.upsertBookIdentifier(bookId, identifierId, label, value);
+			// The form resets from the book prop; re-fetch so the new
+			// identifier row appears.
+			await refreshBook();
 		},
-		[actions],
+		[actions, refreshBook],
 	);
 
 	const onDeleteIdentifier = useCallback(
 		async (bookId: string, identifierId: number) => {
-			if (actions) {
-				await actions.deleteBookIdentifier(bookId, identifierId);
-			}
+			if (!actions) return;
+			await actions.deleteBookIdentifier(bookId, identifierId);
+			await refreshBook();
 		},
-		[actions],
+		[actions, refreshBook],
 	);
 
 	const onReloadBooks = useCallback(async () => {
-		if (actions) {
-			// Drop stale paged-grid pages too, then refresh this route's list.
-			actions.invalidateBooks();
-			await actions.loadBooks();
-		}
-	}, [actions]);
+		if (!actions) return;
+		// Hardcover imports change many fields at once: drop stale grid
+		// pages, then refresh this route's book and tag vocabulary.
+		actions.invalidateBooks();
+		await Promise.all([refreshBook(), refreshTags()]);
+	}, [actions, refreshBook, refreshTags]);
 
-	// Spinner only for the initial fetch; refetches after edits keep the
+	// Spinner only for the initial fetch; refreshes after edits keep the
 	// (stale-for-a-moment) form on screen instead of flashing.
-	if (state !== LibraryState.ready || (loadingBooks && books.length === 0)) {
+	if (state !== LibraryState.ready || loading) {
 		return (
 			<div style={centeredFill}>
 				<Spinner size={18} />
@@ -110,7 +108,7 @@ const EditBookRoute = () => {
 		return (
 			<div style={centeredFill}>
 				<span style={{ fontSize: 13, color: "var(--ctd-ink-soft)" }}>
-					Book not found.
+					{error ?? "Book not found."}
 				</span>
 			</div>
 		);

--- a/src/stores/library/store.ts
+++ b/src/stores/library/store.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { create } from "zustand";
 
 import type {
@@ -6,7 +5,6 @@ import type {
 	BookUpdate,
 	ImportableBookMetadata,
 	LibraryAuthor,
-	LibraryBook,
 	LibrarySeries,
 	NewAuthor,
 } from "@/bindings";
@@ -38,15 +36,6 @@ export enum LibraryState {
 
 interface LibraryActions {
 	// Core actions
-	/**
-	 * Loads the ENTIRE library into `books` via clb_query_list_all_books.
-	 *
-	 * No page consumes this anymore: the Authors page rides on the authors
-	 * payload, the cover grid pages via `ensureBookRange`, and the book
-	 * edit route fetches its own book and the tag vocabulary (see
-	 * useEditBookData).
-	 */
-	loadBooks: () => Promise<void>;
 	loadAuthors: () => Promise<void>;
 	loadSeries: () => Promise<void>;
 	initialize: (libraryPath: string) => Promise<void>;
@@ -104,14 +93,6 @@ interface LibraryStoreState {
 	libraryState: LibraryState;
 	libraryError: Error | null;
 
-	// Whole-library book list (lazy; see LibraryActions.loadBooks)
-	books: LibraryBook[];
-	booksLoading: boolean;
-	booksError: string | null;
-	/** Bumped by invalidateBooks; the full list is fresh iff it matches. */
-	allBooksGeneration: number;
-	allBooksLoadedGeneration: number;
-
 	// Paged book grid state
 	bookFilter: BookGridFilter;
 	bookCache: PagedBookCache;
@@ -137,11 +118,6 @@ const initialState = {
 	library: null,
 	libraryState: LibraryState.uninitialized,
 	libraryError: null,
-	books: [],
-	booksLoading: false,
-	booksError: null,
-	allBooksGeneration: 0,
-	allBooksLoadedGeneration: -1,
 	bookFilter: ALL_BOOKS_FILTER,
 	bookCache: emptyBookCache(serializeBookFilter(ALL_BOOKS_FILTER), 0),
 	bookPagesError: null,
@@ -162,7 +138,6 @@ const localLibraryFromPath = (path: string): Options => ({
 
 // In-flight de-dupe (module scope: promises are not store state).
 const inFlightBookPages = new Map<string, Promise<void>>();
-let inFlightAllBooks: Promise<void> | null = null;
 
 export const useLibraryStore = create<LibraryStoreState>((set, get) => {
 	const fetchBookPage = (
@@ -229,34 +204,6 @@ export const useLibraryStore = create<LibraryStoreState>((set, get) => {
 
 		// Stable actions object - ALL actions go here, created once and never change
 		actions: {
-			loadBooks: async () => {
-				const { library } = get();
-				if (!library) return;
-				if (inFlightAllBooks) return inFlightAllBooks;
-
-				const generation = get().allBooksGeneration;
-				set({ booksLoading: true, booksError: null });
-				inFlightAllBooks = (async () => {
-					try {
-						const books = await library.listBooks();
-						set({
-							books,
-							booksLoading: false,
-							allBooksLoadedGeneration: generation,
-						});
-					} catch (error) {
-						set({
-							booksError:
-								error instanceof Error ? error.message : "Failed to load books",
-							booksLoading: false,
-						});
-					} finally {
-						inFlightAllBooks = null;
-					}
-				})();
-				return inFlightAllBooks;
-			},
-
 			loadAuthors: async () => {
 				const { library } = get();
 				if (!library) return;
@@ -330,7 +277,6 @@ export const useLibraryStore = create<LibraryStoreState>((set, get) => {
 			invalidateBooks: () => {
 				set((state) => ({
 					bookCache: invalidateBookCache(state.bookCache),
-					allBooksGeneration: state.allBooksGeneration + 1,
 				}));
 				// Mutations can rename/create series, change the library size,
 				// and change per-author book counts (which ride on the authors
@@ -349,8 +295,6 @@ export const useLibraryStore = create<LibraryStoreState>((set, get) => {
 				set((state) => ({
 					libraryState: LibraryState.initializing,
 					libraryError: null,
-					books: [],
-					allBooksLoadedGeneration: -1,
 					bookCache: emptyBookCache(
 						state.bookCache.key,
 						state.bookCache.generation + 1,
@@ -524,33 +468,6 @@ export const useBookPagesError = () =>
 	useLibraryStore((state) => state.bookPagesError);
 export const useLibraryTotal = () =>
 	useLibraryStore((state) => state.libraryTotal);
-
-/**
- * The whole-library book list, loaded lazily on first use and reloaded
- * after mutations mark it stale. Only for consumers that genuinely need
- * every book (see LibraryActions.loadBooks); the cover grid pages instead.
- */
-export const useAllBooks = (): { books: LibraryBook[]; loading: boolean } => {
-	const books = useLibraryStore((state) => state.books);
-	const loading = useLibraryStore((state) => state.booksLoading);
-	// Both generations (not a derived boolean) so the effect re-fires when a
-	// load lands but a newer invalidation already superseded it.
-	const generation = useLibraryStore((state) => state.allBooksGeneration);
-	const loadedGeneration = useLibraryStore(
-		(state) => state.allBooksLoadedGeneration,
-	);
-	const ready = useLibraryReady();
-	const actions = useLibraryActions();
-
-	const stale = loadedGeneration !== generation;
-	useEffect(() => {
-		if (ready && loadedGeneration !== generation) {
-			void actions.loadBooks();
-		}
-	}, [ready, generation, loadedGeneration, actions]);
-
-	return { books, loading: loading || (stale && books.length === 0) };
-};
 
 // Selectors for authors
 export const useAuthors = () => useLibraryStore((state) => state.authors);

--- a/src/stores/library/store.ts
+++ b/src/stores/library/store.ts
@@ -41,12 +41,10 @@ interface LibraryActions {
 	/**
 	 * Loads the ENTIRE library into `books` via clb_query_list_all_books.
 	 *
-	 * Kept (and loaded lazily, see `useAllBooks`) for the consumers that
-	 * genuinely need whole-library data and have no targeted query:
-	 * - the book detail route: the tag autocomplete needs the full tag
-	 *   vocabulary (and there is no fetch-one-book command).
-	 * The Authors page no longer uses this (per-author book counts ride on
-	 * the authors payload); the cover grid pages via `ensureBookRange`.
+	 * No page consumes this anymore: the Authors page rides on the authors
+	 * payload, the cover grid pages via `ensureBookRange`, and the book
+	 * edit route fetches its own book and the tag vocabulary (see
+	 * useEditBookData).
 	 */
 	loadBooks: () => Promise<void>;
 	loadAuthors: () => Promise<void>;


### PR DESCRIPTION
## Problem

At 5,000 books, every save on the book edit route (`books.$bookId`) triggered `clb_query_list_all_books` — a full whole-library rehydration. That cost ~340ms per save before the `has_cover` stat fix and ~35–40ms after, but it stays linear in library size and is pure waste for a one-field edit: the route only ever needed (a) its own book and (b) the full tag vocabulary for the tag autocomplete. The trigger was `useAllBooks` reacting to the post-mutation `allBooksGeneration` bump.

## What changed

**Backend**
- `libcalibre`: `Library::list_tags()` + `TagSummary` (id, name; case-insensitive name sort), mirroring the `list_series`/`SeriesSummary` shape, with fixture tests in `query_test.rs`.
- `src-tauri`: `clb_query_get_book(book_id)` returns one `LibraryBook` hydrated exactly like a `clb_query_books` page item (`Library::get_book` shares the same field set including read state; cover URL and per-author book counts via the existing `to_library_book`). `clb_query_list_tags` exposes the vocabulary. `bindings.ts` hand-edited in specta order/style.

**Frontend**
- New `useEditBookData(bookId)` hook: fetches the book + tag vocabulary on mount, re-fetches the book after its own saves and identifier changes, and re-fetches tags only when a save's `tag_list` actually changed (`tagListChanged`, unit-tested).
- Saves keep bumping the paged-grid cache generation, so the grid still refreshes with exactly one visible-page refetch.
- A save now costs one `clb_query_get_book` (O(1)) instead of an O(N) list-all.

## Full retirement

With #122 merged (Authors page off `useAllBooks`), the edit route was the last consumer, so the whole path is deleted:

- `useAllBooks` selector and `loadBooks` action
- `books` / `booksLoading` / `booksError` / `allBooksGeneration` / `allBooksLoadedGeneration` store state and the `inFlightAllBooks` de-dupe
- `Library.listBooks` from the service interface and both adapters
- `clbQueryListAllBooks` from `bindings.ts`
- the `clb_query_list_all_books` command and the `book::list_all` helper

`libcalibre`'s `Library::books()` stays — it is public API used by tests and other tools.

## Verification

- `cargo fmt`, `cargo clippy --workspace` (warning count unchanged vs main), `cargo test --workspace` (all 15 binaries green, incl. new `list_tags` tests), `bunx tsc --noEmit`, `bunx biome lint src/` (2 pre-existing warnings, same as main), `bunx vitest run` (178 tests, incl. new `tag.test.ts`).
- Skipped the live save-burst measurement: the whole-library command no longer exists, so the edit route cannot trigger it — the claim is pinned down statically (rg + types) rather than by instrumenting an isolated dev instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)