### PR TITLE
First-run welcome that teaches both ways into a library

### DIFF
--- a/src/components/pages/firstTimeSetup.module.css
+++ b/src/components/pages/firstTimeSetup.module.css
@@ -1,27 +1,89 @@
-/* Centered welcome column filling the window, matching the old
- * Mantine Stack (align center, top-justified, full viewport height). */
+/* First-run welcome. One floating panel centered on the window background,
+ * matching DESIGN.md: neutral chrome, modest (not hero) title, the single
+ * accent reserved for the one primary action, soft shadow on the card only. */
 .page {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 100vh;
+	padding: 24px;
+	background: var(--ctd-bg);
+}
+
+.card {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	justify-content: flex-start;
-	gap: 16px;
-	height: 100vh;
-	padding: 12px;
+	text-align: center;
+	width: 100%;
+	max-width: 380px;
+	padding: 32px 32px 24px;
+	background: var(--ctd-surface);
+	border: 1px solid var(--ctd-border);
+	border-radius: var(--ctd-radius-panel);
+	box-shadow: var(--ctd-shadow-soft);
+}
+
+.mark {
+	display: inline-flex;
+	font-size: 30px;
+	line-height: 1;
+	color: var(--ctd-ink-soft);
 }
 
 .title {
-	margin: 0;
-	font-size: 26px;
-	font-weight: 700;
+	margin: 14px 0 0;
+	font-size: 20px;
+	font-weight: 600;
 	line-height: 1.3;
 	color: var(--ctd-ink);
 }
 
-.text {
-	margin: 0;
+.lede {
+	margin: 6px 0 20px;
 	font-size: 13px;
+	line-height: 1.5;
+	color: var(--ctd-ink-soft);
+	max-width: 30ch;
+}
+
+.busy {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+/* Teaching rows: name the two ways in. Hairline-separated from the action,
+ * left-aligned so the lead-in reads as a scannable label. */
+.paths {
+	list-style: none;
+	margin: 20px 0 0;
+	padding: 16px 0 0;
+	width: 100%;
+	border-top: 1px solid var(--ctd-border);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.path {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+	text-align: left;
+	font-size: 12.5px;
 	line-height: 1.45;
+	color: var(--ctd-ink-soft);
+}
+
+.pathIcon {
+	flex: none;
+	margin-top: 1px;
+	font-size: 15px;
+	color: var(--ctd-ink-soft);
+}
+
+.pathLead {
+	font-weight: 600;
 	color: var(--ctd-ink);
-	text-align: center;
 }

--- a/src/components/pages/firstTimeSetup.stories.tsx
+++ b/src/components/pages/firstTimeSetup.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FirstTimeSetupView } from "./firstTimeSetup";
+
+const meta: Meta<typeof FirstTimeSetupView> = {
+	title: "Pages/FirstTimeSetup",
+	component: FirstTimeSetupView,
+	parameters: { layout: "fullscreen" },
+	args: {
+		onChooseFolder: () => {},
+	},
+};
+export default meta;
+
+type Story = StoryObj<typeof FirstTimeSetupView>;
+
+/** Cold first launch: no library configured yet. */
+export const Default: Story = {};
+
+/** After a folder is picked, while the library is opened or created. */
+export const Busy: Story = {
+	args: { busy: true },
+};

--- a/src/components/pages/firstTimeSetup.tsx
+++ b/src/components/pages/firstTimeSetup.tsx
@@ -1,14 +1,89 @@
 import { commands } from "@/bindings";
-import { Button } from "@/components/ui";
+import { F7BookFill } from "@/components/icons/F7BookFill";
+import { FluentLibraryFilled } from "@/components/icons/FluentLibraryFilled";
+import { Button, Spinner } from "@/components/ui";
 import { safeAsyncEventHandler } from "@/lib/async";
 import { usePlatform } from "@/lib/platform/context";
 import { useLibraryStore } from "@/stores/library/store";
 import { createLibrary, setActiveLibrary } from "@/stores/settings/actions";
+import { useState } from "react";
 import styles from "./firstTimeSetup.module.css";
+
+export interface FirstTimeSetupViewProps {
+	/** Opens the folder picker and provisions the chosen library. */
+	onChooseFolder: () => void;
+	/** While a library is being opened or created, the action shows progress. */
+	busy?: boolean;
+}
+
+/**
+ * First-run welcome. The teaching counterpart to the empty-library state: the
+ * library doesn't exist yet, so this names the two ways in (open an existing
+ * Calibre library, or create a fresh one) before handing off to the folder
+ * picker. Pure renderer — behaviour lives in {@link FirstTimeSetup}.
+ */
+export const FirstTimeSetupView = ({
+	onChooseFolder,
+	busy = false,
+}: FirstTimeSetupViewProps) => {
+	return (
+		<div className={styles.page}>
+			<section className={styles.card} aria-labelledby="fts-title">
+				<span className={styles.mark} aria-hidden="true">
+					<FluentLibraryFilled />
+				</span>
+
+				<h1 id="fts-title" className={styles.title}>
+					Welcome to Citadel
+				</h1>
+				<p className={styles.lede}>
+					Citadel reads and manages your Calibre library. Point it at a folder
+					to get started.
+				</p>
+
+				<Button
+					variant="primary"
+					size="md"
+					fullWidth
+					autoFocus
+					disabled={busy}
+					onClick={onChooseFolder}
+				>
+					{busy ? (
+						<span className={styles.busy}>
+							<Spinner size={14} />
+							Setting up your library…
+						</span>
+					) : (
+						"Choose library folder…"
+					)}
+				</Button>
+
+				<ul className={styles.paths}>
+					<li className={styles.path}>
+						<FluentLibraryFilled className={styles.pathIcon} aria-hidden />
+						<span>
+							<span className={styles.pathLead}>Already use Calibre?</span> Pick
+							your existing library folder to open it here.
+						</span>
+					</li>
+					<li className={styles.path}>
+						<F7BookFill className={styles.pathIcon} aria-hidden />
+						<span>
+							<span className={styles.pathLead}>New to Calibre?</span> Choose an
+							empty folder and Citadel creates a library in it.
+						</span>
+					</li>
+				</ul>
+			</section>
+		</div>
+	);
+};
 
 export const FirstTimeSetup = () => {
 	const actions = useLibraryStore((state) => state.actions);
 	const platform = usePlatform();
+	const [busy, setBusy] = useState(false);
 
 	const openFilePicker = async (): Promise<
 		| { type: "existing library selected"; path: string }
@@ -27,31 +102,24 @@ export const FirstTimeSetup = () => {
 		}
 		return { type: "new library selected", path };
 	};
-	return (
-		<div className={styles.page}>
-			<h1 className={styles.title}>Welcome to Citadel!</h1>
 
-			<p className={styles.text}>
-				Select an existing Calibre library, or choose where to create a new
-				library.
-			</p>
-			<Button
-				variant="primary"
-				onClick={safeAsyncEventHandler(async () => {
-					const returnStatus = await openFilePicker();
-					if (returnStatus.type === "invalid library path selected") {
-						return;
-					}
+	const onChooseFolder = safeAsyncEventHandler(async () => {
+		const returnStatus = await openFilePicker();
+		if (returnStatus.type === "invalid library path selected") {
+			return;
+		}
 
-					if (returnStatus.type === "new library selected") {
-						await actions.createLibrary(returnStatus.path);
-					}
-					const newLibraryId = await createLibrary(returnStatus.path);
-					await setActiveLibrary(newLibraryId);
-				})}
-			>
-				Choose Calibre library folder
-			</Button>
-		</div>
-	);
+		setBusy(true);
+		try {
+			if (returnStatus.type === "new library selected") {
+				await actions.createLibrary(returnStatus.path);
+			}
+			const newLibraryId = await createLibrary(returnStatus.path);
+			await setActiveLibrary(newLibraryId);
+		} finally {
+			setBusy(false);
+		}
+	});
+
+	return <FirstTimeSetupView onChooseFolder={onChooseFolder} busy={busy} />;
 };


### PR DESCRIPTION
The cold-start screen (shown when no library is configured yet) was a bare title + a single button. This redesigns it into a quiet, on-brand welcome that **teaches** the two ways in — the first-run counterpart to CDL-11's empty-library state.

## What changed
- **Teaching welcome** — a floating card naming both paths: *"Already use Calibre?"* (open an existing library) and *"New to Calibre?"* (create a fresh one). This also clarifies the single folder picker's two outcomes, which were previously invisible.
- **On-brand visuals** — follows `DESIGN.md`: neutral chrome, modest 600-weight title (not hero), the single accent reserved for the one primary action, soft shadow on the card only, no gradients. Quiet library glyph as a typographic mark (no empty-state art).
- **Busy state** — library creation is async; the action now shows *"Setting up your library…"* with a spinner instead of a dead button.
- **Testable structure** — split into a pure `FirstTimeSetupView` (mirrors how `BookPage` is structured per the repo's functional-core/imperative-shell rule) plus a thin behavior wrapper. Adds `Pages/FirstTimeSetup` stories (Default + Busy) for isolated light/dark iteration in Storybook.

## Verification
- `tsc` clean, `biome` format + lint clean on changed files.
- Rendered live in the dev app at a simulated cold start (no library configured) — copy and layout confirmed. Dark mode is covered by the new Storybook story (the WebDriver plugin only snapshots light scheme).

Relates to CDL-11 (empty states that teach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)