### PR TITLE
chore(libcalibre): delete dead api.rs

### DIFF
--- a/crates/libcalibre/src/api.rs
+++ b/crates/libcalibre/src/api.rs
@@ -1,3 +1,0 @@
-pub mod authors;
-pub mod book_files;
-pub mod books;


### PR DESCRIPTION
`crates/libcalibre/src/api.rs` declared `pub mod authors; pub mod book_files; pub mod books;` for modules that no longer exist. It only ever compiled because `lib.rs` never declared `mod api`. Leftover from the pre-facade structure.

Verified nothing references `mod api` / `api::`, and `cargo build -p libcalibre` is clean after removal.

Fixes CDL-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)