### PR TITLE
docs: drop Node from dev prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ xattr -d com.apple.quarantine /Applications/Citadel.app/
 
 ## Developing
 
-As a prerequisite, you'll need to install [Bun](https://bun.sh), Node[^1], and [Rust](https://www.rust-lang.org/tools/install).
+As a prerequisite, you'll need to install [Bun](https://bun.sh) and [Rust](https://www.rust-lang.org/tools/install).
 
 Then, you can install the packages.
 
@@ -109,5 +109,3 @@ excellent
 [Calibre redesign Figma prototype](https://old.reddit.com/r/Calibre/comments/udzumn/testing_a_new_interface_for_calibre/),
 from which Citadel takes inspiration.
 Thank you, Kemie!
-
-[^1]: https://github.com/every-day-things/citadel/issues/9


### PR DESCRIPTION
The README listed Node as a dev prerequisite, a holdover from the Svelte/Tauri-1 era.

Verified node-free dev works: with `node` confirmed off PATH, `bun run build:web` ran route generation + `tsc` + `vite build` to completion. (Bun supplies the JS runtime; cargo/Rust handles the backend.)

- Removed Node from the prerequisites line
- Dropped the now-orphaned `[^1]` issue-9 footnote

Not yet checked on a machine with Node *never installed* — PATH-stripping is near-identical but not byte-for-byte.

Fixes CDL-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)