### PR TITLE
chore(release): bump version to v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "build": "bun run build:app",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "citadel-rs"
-version = "0.6.0"
+version = "0.6.1"
 description = "Backend for Citadel, embedded into the Tauri app or run stand-alone."
 authors = ["Phil Denhoff"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
   },
   "productName": "Citadel",
   "mainBinaryName": "Citadel",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "software.everydaythings.citadel",
   "plugins": {
     "updater": {


### PR DESCRIPTION
Automated release version bump generated by the Release workflow.

Files updated:
- package.json
- src-tauri/Cargo.toml
- src-tauri/tauri.conf.json