### PR TITLE
feat(onboarding): backend surface for detection-led first-run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,16 @@ debug build with zero `com.apple.TCC` log events at the moment of access.
 TCC-protected user folders are Desktop/Documents/Downloads and app data like
 Photos or Mail. When checking, use `/usr/bin/log show --predicate 'subsystem ==
 "com.apple.TCC"'` — bare `log` is a zsh builtin that silently shadows it.
+
+## SQLite on macOS persists WAL sidecars
+
+Citadel links Apple's system SQLite (`/usr/lib/libsqlite3.dylib`), which
+enables `SQLITE_FCNTL_PERSIST_WAL` by default: `-wal`/`-shm` sidecars survive
+a clean close of the last connection, for every WAL database and every
+connection (verified empirically 2026-07-10, CDL-19 — even `/usr/bin/sqlite3`
+leaves them). No connection-level dance (`PRAGMA query_only` off, explicit
+`wal_checkpoint`, even `journal_mode=DELETE`) removes both files; a connection
+that ever set `query_only=ON` additionally never checkpoints at close. Don't
+write tests asserting sidecar deletion — assert the database file's bytes are
+unchanged and tolerate the two sidecars. Calibre-managed libraries are
+journal-mode and stay fully byte-clean under read-only access.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,14 @@ the background — no window focus, no macOS permissions:
 `tauri-wd` (W3C WebDriver CLI for WebDriverIO suites) launches its own app
 instance — never run it while `bun run dev` is up; two instances fight over the
 settings store and library database.
+
+## macOS permissions (TCC)
+
+Reading `~/Library/Preferences/**` from the app process (e.g. Calibre's
+`global.py.json` for library detection) triggers no TCC prompt and needs no
+entitlement — Preferences is not a TCC-protected location for non-sandboxed
+apps. Verified empirically 2026-07-10 (CDL-19): the read succeeded in a live
+debug build with zero `com.apple.TCC` log events at the moment of access.
+TCC-protected user folders are Desktop/Documents/Downloads and app data like
+Photos or Mail. When checking, use `/usr/bin/log show --predicate 'subsystem ==
+"com.apple.TCC"'` — bare `log` is a zsh builtin that silently shadows it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-webdriver-automation",
  "tauri-specta",
+ "tempfile",
  "urlencoding",
  "uuid",
  "zip 0.6.6",

--- a/crates/libcalibre/src/lib.rs
+++ b/crates/libcalibre/src/lib.rs
@@ -11,6 +11,7 @@ pub mod persistence;
 mod queries;
 pub(crate) mod schema;
 pub mod sorting;
+pub mod stats;
 pub mod types;
 pub mod util;
 
@@ -22,6 +23,7 @@ pub use library::{
     BookIdentifier, BookPage, BookQuery, BookSortOrder, BookUpdate, Library, SeriesSummary,
     TagSummary,
 };
+pub use stats::{library_stats, LibraryStats};
 pub use types::{AuthorId, BookFileId, BookId};
 
 // Keep entity exports that are needed internally (for operations/queries)

--- a/crates/libcalibre/src/stats.rs
+++ b/crates/libcalibre/src/stats.rs
@@ -1,0 +1,38 @@
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+
+use crate::error::CalibreError;
+use crate::util::ValidDbPath;
+
+/// Headline counts for a library, cheap enough to run against a library the
+/// user has only pointed at (onboarding's post-open reveal): two COUNT
+/// queries, no book-row hydration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LibraryStats {
+    pub book_count: i64,
+    pub author_count: i64,
+}
+
+/// Count books and authors in the library at `db_path` without adopting it.
+///
+/// Deliberately NOT [`crate::persistence::establish_connection`]: that flips
+/// the journal mode to WAL and re-registers triggers — persistent changes to
+/// a database the user has only *pointed at*, not opened. `query_only` turns
+/// any accidental write into a hard error; `busy_timeout` tolerates a
+/// concurrently running Calibre/Citadel holding the write lock.
+pub fn library_stats(db_path: &ValidDbPath) -> Result<LibraryStats, CalibreError> {
+    use crate::schema::{authors, books};
+
+    let mut conn =
+        SqliteConnection::establish(&db_path.database_path).map_err(CalibreError::database)?;
+    conn.batch_execute("PRAGMA query_only = ON; PRAGMA busy_timeout = 3000;")
+        .map_err(CalibreError::database)?;
+
+    let book_count = books::table.count().get_result(&mut conn)?;
+    let author_count = authors::table.count().get_result(&mut conn)?;
+
+    Ok(LibraryStats {
+        book_count,
+        author_count,
+    })
+}

--- a/crates/libcalibre/src/stats.rs
+++ b/crates/libcalibre/src/stats.rs
@@ -20,6 +20,13 @@ pub struct LibraryStats {
 /// a database the user has only *pointed at*, not opened. `query_only` turns
 /// any accidental write into a hard error; `busy_timeout` tolerates a
 /// concurrently running Calibre/Citadel holding the write lock.
+///
+/// Calibre-managed libraries are journal-mode and stay byte-clean under this
+/// read. A WAL-mode database (one Citadel itself opened before) additionally
+/// grows `-wal`/`-shm` sidecars: reading WAL requires them, and on macOS they
+/// survive close for every connection app-wide — Apple's system SQLite
+/// enables `SQLITE_FCNTL_PERSIST_WAL` by default. The database file itself is
+/// never modified either way.
 pub fn library_stats(db_path: &ValidDbPath) -> Result<LibraryStats, CalibreError> {
     use crate::schema::{authors, books};
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,6 +46,9 @@ tauri-plugin-updater = "2"
 tauri-plugin-webdriver-automation = "0.1.3"
 image = { version = "0.25.6", default-features = false, features = ["jpeg", "png"] }
 
+[dev-dependencies]
+tempfile = "3.8"
+
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!
 custom-protocol = [ "tauri/custom-protocol" ]

--- a/src-tauri/src/libs/calibre/command.rs
+++ b/src-tauri/src/libs/calibre/command.rs
@@ -7,8 +7,15 @@ use crate::libs::cover_thumbs::{self, CoverThumbnail};
 use crate::state::CitadelState;
 
 use super::custom_columns::CustomValueDto;
+use super::onboarding::{self, CreateTargetBlocker};
 use super::AuthorUpdate;
 use super::BookUpdate;
+
+/// Exact error strings `clb_cmd_create_library` returns when it refuses the
+/// target folder. The frontend matches on them to offer alternatives: "open
+/// it instead" for an existing library, "pick another folder" for content.
+pub const ERR_CREATE_LIBRARY_TARGET_IS_LIBRARY: &str = "create-library/already-a-library";
+pub const ERR_CREATE_LIBRARY_TARGET_NOT_EMPTY: &str = "create-library/folder-not-empty";
 
 #[tauri::command]
 #[specta::specta]
@@ -50,6 +57,20 @@ pub fn clb_cmd_create_library(
     handle: tauri::AppHandle,
     library_root: String,
 ) -> Result<(), String> {
+    // Never unpack into a folder that already holds anything real: extraction
+    // into a populated folder silently interleaves library files with the
+    // user's data. A missing folder is fine — extract() creates it.
+    match onboarding::create_target_blocker(std::path::Path::new(&library_root)) {
+        Ok(None) => {}
+        Ok(Some(CreateTargetBlocker::AlreadyALibrary)) => {
+            return Err(ERR_CREATE_LIBRARY_TARGET_IS_LIBRARY.to_string())
+        }
+        Ok(Some(CreateTargetBlocker::NotEmpty)) => {
+            return Err(ERR_CREATE_LIBRARY_TARGET_NOT_EMPTY.to_string())
+        }
+        Err(e) => return Err(format!("Failed to inspect '{library_root}': {e}")),
+    }
+
     let resource_path = handle
         .path()
         .resolve(

--- a/src-tauri/src/libs/calibre/mod.rs
+++ b/src-tauri/src/libs/calibre/mod.rs
@@ -11,6 +11,7 @@ mod book;
 
 pub mod command;
 pub mod custom_columns;
+pub mod onboarding;
 pub mod query;
 
 #[derive(Serialize, Deserialize, specta::Type, Debug)]

--- a/src-tauri/src/libs/calibre/onboarding.rs
+++ b/src-tauri/src/libs/calibre/onboarding.rs
@@ -1,0 +1,539 @@
+//! Detection-led first-run onboarding: find an existing Calibre library,
+//! judge candidate paths (cloud-sync risk, create-target validity), and
+//! suggest where a brand-new library should live.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Where [`detect_calibre_library`] found its hit.
+#[derive(Serialize, Deserialize, specta::Type, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DetectionSource {
+    /// `library_path` in Calibre's own `global.py.json`.
+    CalibreConfig,
+    /// Calibre's default `~/Calibre Library` folder.
+    DefaultFolder,
+}
+
+#[derive(Serialize, Deserialize, specta::Type, Clone, Debug, PartialEq, Eq)]
+pub struct DetectedLibrary {
+    pub path: String,
+    pub source: DetectionSource,
+}
+
+/// Best-effort cloud-sync verdict for a candidate library path. Informational
+/// only — the UX warns, it never blocks. Unknown providers (Seafile, Syncthing,
+/// …) report `synced: false`.
+#[derive(Serialize, Deserialize, specta::Type, Clone, Debug, PartialEq, Eq)]
+pub struct SyncStatus {
+    pub synced: bool,
+    pub provider: Option<String>,
+}
+
+/// Find an existing Calibre library: the location Calibre itself records in
+/// its config wins; otherwise probe Calibre's default folder. Either candidate
+/// must actually hold a `metadata.db` (via `get_db_path`) or it falls through.
+pub fn detect_calibre_library(home: &Path) -> Option<DetectedLibrary> {
+    detect_from(calibre_config_file(home).as_deref(), home)
+}
+
+/// Testable core of [`detect_calibre_library`]: the config-file location is
+/// explicit instead of resolved from the host OS.
+fn detect_from(config_file: Option<&Path>, home: &Path) -> Option<DetectedLibrary> {
+    if let Some(path) = config_file.and_then(configured_library_path) {
+        if libcalibre::util::get_db_path(&path).is_some() {
+            return Some(DetectedLibrary {
+                path,
+                source: DetectionSource::CalibreConfig,
+            });
+        }
+    }
+
+    let default_folder = home.join("Calibre Library").to_string_lossy().into_owned();
+    if libcalibre::util::get_db_path(&default_folder).is_some() {
+        return Some(DetectedLibrary {
+            path: default_folder,
+            source: DetectionSource::DefaultFolder,
+        });
+    }
+
+    None
+}
+
+/// Calibre's `global.py.json` for the host OS. All branches are plain path
+/// math, so every platform's resolution stays unit-testable from any host.
+fn calibre_config_file(home: &Path) -> Option<PathBuf> {
+    if cfg!(target_os = "macos") {
+        Some(macos_calibre_config(home))
+    } else if cfg!(windows) {
+        windows_calibre_config(std::env::var_os("APPDATA").map(PathBuf::from))
+    } else {
+        Some(unix_calibre_config(
+            home,
+            std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from),
+        ))
+    }
+}
+
+fn macos_calibre_config(home: &Path) -> PathBuf {
+    home.join("Library/Preferences/calibre/global.py.json")
+}
+
+/// `$XDG_CONFIG_HOME/calibre/global.py.json`; the XDG spec says a missing or
+/// relative `$XDG_CONFIG_HOME` means `~/.config`.
+fn unix_calibre_config(home: &Path, xdg_config_home: Option<PathBuf>) -> PathBuf {
+    xdg_config_home
+        .filter(|dir| dir.is_absolute())
+        .unwrap_or_else(|| home.join(".config"))
+        .join("calibre/global.py.json")
+}
+
+fn windows_calibre_config(appdata: Option<PathBuf>) -> Option<PathBuf> {
+    appdata.map(|dir| dir.join("calibre").join("global.py.json"))
+}
+
+/// `library_path` from a Calibre `global.py.json`. A missing file, unreadable
+/// file, malformed JSON, missing key, or non-string value all mean "nothing
+/// configured" — detection falls through, it never errors.
+fn configured_library_path(config_file: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(config_file).ok()?;
+    let config: serde_json::Value = serde_json::from_str(&text).ok()?;
+    Some(config.get("library_path")?.as_str()?.to_string())
+}
+
+/// Suggested location for a brand-new library: `~/Citadel` (macOS/Linux),
+/// `%USERPROFILE%\Citadel` (Windows). Only resolved here — creation happens
+/// in `clb_cmd_create_library` once the user confirms.
+pub fn default_new_library_path(home: &Path) -> String {
+    home.join("Citadel").to_string_lossy().into_owned()
+}
+
+pub fn path_sync_status(path: &Path) -> SyncStatus {
+    match sync_provider(path) {
+        Some(provider) => SyncStatus {
+            synced: true,
+            provider: Some(provider),
+        },
+        None => SyncStatus {
+            synced: false,
+            provider: None,
+        },
+    }
+}
+
+/// Best-effort provider identification, in two passes:
+///
+/// 1. Path components:
+///    - `Mobile Documents` — every iCloud-synced container lives under
+///      `~/Library/Mobile Documents/` (iCloud Drive proper is its
+///      `com~apple~CloudDocs` child).
+///    - `CloudStorage` — macOS File Provider roots mount as
+///      `~/Library/CloudStorage/<Provider>-<Account>`; anything under it is
+///      synced by definition, known or not.
+///    - `Dropbox` / `OneDrive*` / `Google Drive` / `GoogleDrive` — the
+///      classic app-managed folder names. OneDrive matches as a prefix
+///      because business accounts name it "OneDrive - <Org>"; `GoogleDrive`
+///      is the stream-mount volume name (`/Volumes/GoogleDrive/My Drive`).
+/// 2. Well-known marker entries in ancestors: a Dropbox root carries a hidden
+///    `.dropbox.cache` dir (legacy clients, a `.dropbox` file) even when the
+///    folder was renamed or relocated.
+fn sync_provider(path: &Path) -> Option<String> {
+    let components: Vec<String> = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+
+    for (i, name) in components.iter().enumerate() {
+        if name == "Mobile Documents" {
+            return Some("iCloud Drive".to_string());
+        }
+        if name == "CloudStorage" {
+            if let Some(root) = components.get(i + 1) {
+                return Some(cloud_storage_provider(root));
+            }
+        }
+        if name.eq_ignore_ascii_case("Dropbox") {
+            return Some("Dropbox".to_string());
+        }
+        if name.to_ascii_lowercase().starts_with("onedrive") {
+            return Some("OneDrive".to_string());
+        }
+        if name.eq_ignore_ascii_case("Google Drive") || name.eq_ignore_ascii_case("GoogleDrive") {
+            return Some("Google Drive".to_string());
+        }
+    }
+
+    for dir in path.ancestors() {
+        if dir.join(".dropbox.cache").exists() || dir.join(".dropbox").exists() {
+            return Some("Dropbox".to_string());
+        }
+    }
+
+    None
+}
+
+/// File Provider roots look like `GoogleDrive-user@gmail.com`,
+/// `OneDrive-Personal`, or plain `Dropbox`. Unknown prefixes still count as
+/// synced (the location itself proves it); the raw prefix names the provider.
+fn cloud_storage_provider(root_folder: &str) -> String {
+    let prefix = root_folder.split('-').next().unwrap_or(root_folder);
+    match prefix {
+        "GoogleDrive" => "Google Drive".to_string(),
+        "OneDrive" => "OneDrive".to_string(),
+        "Dropbox" => "Dropbox".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Why `clb_cmd_create_library` refuses a target folder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CreateTargetBlocker {
+    /// Target already contains a `metadata.db`; the frontend offers "open it
+    /// instead".
+    AlreadyALibrary,
+    /// Target exists and holds real (non-junk) content, or is a file.
+    NotEmpty,
+}
+
+/// OS droppings that don't make a folder "non-empty". Compared
+/// case-insensitively; `Thumbs.db`/`desktop.ini` casing varies on Windows.
+const JUNK_FILES: &[&str] = &[".ds_store", ".localized", "thumbs.db", "desktop.ini"];
+
+fn is_junk(file_name: &str) -> bool {
+    JUNK_FILES.contains(&file_name.to_ascii_lowercase().as_str())
+}
+
+/// A missing target is fine (creation makes the folder); an existing one must
+/// be an empty-ish directory. IO errors (e.g. unreadable folder) propagate —
+/// emptiness can't be verified, so creation must not proceed.
+pub fn create_target_blocker(target: &Path) -> std::io::Result<Option<CreateTargetBlocker>> {
+    if !target.exists() {
+        return Ok(None);
+    }
+    if target.join("metadata.db").exists() {
+        return Ok(Some(CreateTargetBlocker::AlreadyALibrary));
+    }
+    if !target.is_dir() {
+        return Ok(Some(CreateTargetBlocker::NotEmpty));
+    }
+    for entry in std::fs::read_dir(target)? {
+        if !is_junk(&entry?.file_name().to_string_lossy()) {
+            return Ok(Some(CreateTargetBlocker::NotEmpty));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    /// The minimum `get_db_path` accepts: a folder holding a `metadata.db`.
+    fn make_library(dir: &Path) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(dir.join("metadata.db"), b"").unwrap();
+    }
+
+    fn write_config(dir: &Path, contents: &str) -> PathBuf {
+        fs::create_dir_all(dir).unwrap();
+        let config = dir.join("global.py.json");
+        fs::write(&config, contents).unwrap();
+        config
+    }
+
+    // ---- configured_library_path -------------------------------------------
+
+    #[test]
+    fn config_parsing_reads_library_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = write_config(
+            tmp.path(),
+            r#"{"language": "en", "library_path": "/books/lib"}"#,
+        );
+        assert_eq!(
+            configured_library_path(&config),
+            Some("/books/lib".to_string())
+        );
+    }
+
+    #[test]
+    fn config_parsing_tolerates_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(configured_library_path(&tmp.path().join("nope.json")), None);
+    }
+
+    #[test]
+    fn config_parsing_tolerates_missing_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = write_config(tmp.path(), r#"{"language": "en"}"#);
+        assert_eq!(configured_library_path(&config), None);
+    }
+
+    #[test]
+    fn config_parsing_tolerates_malformed_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = write_config(tmp.path(), "{library_path: not json");
+        assert_eq!(configured_library_path(&config), None);
+    }
+
+    #[test]
+    fn config_parsing_tolerates_non_string_value() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = write_config(tmp.path(), r#"{"library_path": null}"#);
+        assert_eq!(configured_library_path(&config), None);
+    }
+
+    // ---- detect_from --------------------------------------------------------
+
+    #[test]
+    fn detection_prefers_configured_library() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let configured = home.join("My Books");
+        make_library(&configured);
+        make_library(&home.join("Calibre Library"));
+        let config = write_config(
+            home,
+            &format!(r#"{{"library_path": {}}}"#, json_str(&configured)),
+        );
+
+        let hit = detect_from(Some(&config), home).unwrap();
+        assert_eq!(hit.source, DetectionSource::CalibreConfig);
+        assert_eq!(hit.path, configured.to_string_lossy());
+    }
+
+    #[test]
+    fn detection_falls_back_when_configured_path_is_not_a_library() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let fallback = home.join("Calibre Library");
+        make_library(&fallback);
+        let config = write_config(
+            home,
+            &format!(
+                r#"{{"library_path": {}}}"#,
+                json_str(&home.join("gone-away"))
+            ),
+        );
+
+        let hit = detect_from(Some(&config), home).unwrap();
+        assert_eq!(hit.source, DetectionSource::DefaultFolder);
+        assert_eq!(hit.path, fallback.to_string_lossy());
+    }
+
+    #[test]
+    fn detection_falls_back_when_config_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        make_library(&home.join("Calibre Library"));
+
+        let hit = detect_from(Some(&home.join("no-config.json")), home).unwrap();
+        assert_eq!(hit.source, DetectionSource::DefaultFolder);
+    }
+
+    #[test]
+    fn detection_returns_none_without_any_library() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(detect_from(None, tmp.path()), None);
+    }
+
+    #[test]
+    fn detection_ignores_default_folder_without_metadata_db() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(tmp.path().join("Calibre Library")).unwrap();
+        assert_eq!(detect_from(None, tmp.path()), None);
+    }
+
+    fn json_str(path: &Path) -> String {
+        serde_json::to_string(&path.to_string_lossy()).unwrap()
+    }
+
+    // ---- per-OS config locations -------------------------------------------
+
+    #[test]
+    fn macos_config_lives_in_library_preferences() {
+        assert_eq!(
+            macos_calibre_config(Path::new("/Users/test")),
+            Path::new("/Users/test/Library/Preferences/calibre/global.py.json")
+        );
+    }
+
+    #[test]
+    fn unix_config_defaults_to_dot_config() {
+        assert_eq!(
+            unix_calibre_config(Path::new("/home/test"), None),
+            Path::new("/home/test/.config/calibre/global.py.json")
+        );
+    }
+
+    #[test]
+    fn unix_config_respects_xdg_config_home() {
+        assert_eq!(
+            unix_calibre_config(Path::new("/home/test"), Some(PathBuf::from("/xdg"))),
+            Path::new("/xdg/calibre/global.py.json")
+        );
+    }
+
+    #[test]
+    fn unix_config_ignores_relative_xdg_config_home() {
+        assert_eq!(
+            unix_calibre_config(Path::new("/home/test"), Some(PathBuf::from("rel/config"))),
+            Path::new("/home/test/.config/calibre/global.py.json")
+        );
+    }
+
+    #[test]
+    fn windows_config_requires_appdata() {
+        assert_eq!(windows_calibre_config(None), None);
+        // Component-wise comparison: the host separator differs when this
+        // test runs on macOS/Linux.
+        let appdata = PathBuf::from(r"C:\Users\test\AppData\Roaming");
+        let config = windows_calibre_config(Some(appdata.clone())).unwrap();
+        assert!(config.starts_with(&appdata));
+        assert!(config.ends_with(Path::new("calibre").join("global.py.json")));
+    }
+
+    // ---- default_new_library_path ------------------------------------------
+
+    #[test]
+    fn default_new_library_is_home_citadel() {
+        assert_eq!(
+            default_new_library_path(Path::new("/Users/test")),
+            "/Users/test/Citadel"
+        );
+    }
+
+    // ---- path_sync_status ---------------------------------------------------
+
+    fn provider_for(path: &str) -> Option<String> {
+        path_sync_status(Path::new(path)).provider
+    }
+
+    #[test]
+    fn sync_detects_icloud_mobile_documents() {
+        assert_eq!(
+            provider_for("/Users/test/Library/Mobile Documents/com~apple~CloudDocs/Books"),
+            Some("iCloud Drive".to_string())
+        );
+    }
+
+    #[test]
+    fn sync_detects_cloud_storage_providers() {
+        assert_eq!(
+            provider_for("/Users/test/Library/CloudStorage/GoogleDrive-x@y.com/My Drive/Books"),
+            Some("Google Drive".to_string())
+        );
+        assert_eq!(
+            provider_for("/Users/test/Library/CloudStorage/OneDrive-Personal/Books"),
+            Some("OneDrive".to_string())
+        );
+        assert_eq!(
+            provider_for("/Users/test/Library/CloudStorage/Dropbox/Books"),
+            Some("Dropbox".to_string())
+        );
+    }
+
+    #[test]
+    fn sync_reports_unknown_cloud_storage_roots_as_synced() {
+        let status = path_sync_status(Path::new("/Users/test/Library/CloudStorage/Box-Box/Books"));
+        assert!(status.synced);
+        assert_eq!(status.provider, Some("Box".to_string()));
+    }
+
+    #[test]
+    fn sync_detects_classic_folder_names() {
+        assert_eq!(
+            provider_for("/Users/test/Dropbox/Books"),
+            Some("Dropbox".to_string())
+        );
+        assert_eq!(
+            provider_for("/Users/test/OneDrive - Acme Corp/Books"),
+            Some("OneDrive".to_string())
+        );
+        assert_eq!(
+            provider_for("/Users/test/Google Drive/My Drive/Books"),
+            Some("Google Drive".to_string())
+        );
+        assert_eq!(
+            provider_for("/Volumes/GoogleDrive/My Drive/Books"),
+            Some("Google Drive".to_string())
+        );
+    }
+
+    #[test]
+    fn sync_detects_dropbox_marker_in_ancestor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().join("Synced");
+        let books = root.join("Books");
+        fs::create_dir_all(&books).unwrap();
+        fs::create_dir_all(root.join(".dropbox.cache")).unwrap();
+
+        let status = path_sync_status(&books);
+        assert!(status.synced);
+        assert_eq!(status.provider, Some("Dropbox".to_string()));
+    }
+
+    #[test]
+    fn sync_reports_unknown_providers_as_not_synced() {
+        // Best-effort by design: Seafile and plain local paths report unsynced.
+        assert!(!path_sync_status(Path::new("/Users/test/Seafile/Books")).synced);
+        assert!(!path_sync_status(Path::new("/Users/test/Documents/Books")).synced);
+    }
+
+    // ---- create_target_blocker ----------------------------------------------
+
+    #[test]
+    fn create_target_accepts_missing_folder() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("new-library");
+        assert_eq!(create_target_blocker(&target).unwrap(), None);
+    }
+
+    #[test]
+    fn create_target_accepts_empty_folder() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(create_target_blocker(tmp.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn create_target_ignores_junk_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join(".DS_Store"), b"").unwrap();
+        fs::write(tmp.path().join("Thumbs.db"), b"").unwrap();
+        assert_eq!(create_target_blocker(tmp.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn create_target_refuses_folder_with_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("notes.txt"), b"hi").unwrap();
+        assert_eq!(
+            create_target_blocker(tmp.path()).unwrap(),
+            Some(CreateTargetBlocker::NotEmpty)
+        );
+    }
+
+    #[test]
+    fn create_target_flags_existing_library_distinctly() {
+        let tmp = tempfile::tempdir().unwrap();
+        make_library(tmp.path());
+        assert_eq!(
+            create_target_blocker(tmp.path()).unwrap(),
+            Some(CreateTargetBlocker::AlreadyALibrary)
+        );
+    }
+
+    #[test]
+    fn create_target_refuses_file_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("plain-file");
+        fs::write(&file, b"").unwrap();
+        assert_eq!(
+            create_target_blocker(&file).unwrap(),
+            Some(CreateTargetBlocker::NotEmpty)
+        );
+    }
+}

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -399,6 +399,69 @@ mod tests {
         assert!(result.is_err());
     }
 
+    fn dir_listing(dir: &Path) -> Vec<String> {
+        let mut names: Vec<String> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn library_stats_leave_journal_mode_library_untouched() {
+        let tmp = tempfile::tempdir().unwrap();
+        extract_empty_library(tmp.path());
+
+        let before = dir_listing(tmp.path());
+        let stats = clb_query_library_stats(tmp.path().to_string_lossy().into_owned()).unwrap();
+        assert_eq!(stats.book_count, 0);
+        assert_eq!(dir_listing(tmp.path()), before);
+    }
+
+    /// A WAL-mode library (Citadel itself opened it before) can't stay
+    /// byte-identical on disk: reading WAL requires `-wal`/`-shm` sidecars,
+    /// which macOS persists past close for every connection (see
+    /// `library_stats`). Honest contract: the database file's bytes never
+    /// change, and nothing beyond those two sidecars appears.
+    #[test]
+    fn library_stats_on_wal_mode_library_add_at_most_wal_sidecars() {
+        use diesel::connection::SimpleConnection;
+        use diesel::prelude::*;
+
+        let tmp = tempfile::tempdir().unwrap();
+        extract_empty_library(tmp.path());
+
+        let db_file = tmp.path().join("metadata.db");
+        diesel::SqliteConnection::establish(db_file.to_str().unwrap())
+            .unwrap()
+            .batch_execute("PRAGMA journal_mode = WAL;")
+            .unwrap();
+        let db_bytes = std::fs::read(&db_file).unwrap();
+        assert_eq!(
+            &db_bytes[18..20],
+            &[2, 2],
+            "fixture did not persist WAL mode"
+        );
+        let before = dir_listing(tmp.path());
+
+        let stats = clb_query_library_stats(tmp.path().to_string_lossy().into_owned()).unwrap();
+        assert_eq!(stats.book_count, 0);
+        assert_eq!(stats.author_count, 0);
+
+        assert_eq!(std::fs::read(&db_file).unwrap(), db_bytes);
+        let new_files: Vec<String> = dir_listing(tmp.path())
+            .into_iter()
+            .filter(|name| !before.contains(name))
+            .collect();
+        assert!(
+            new_files
+                .iter()
+                .all(|name| name == "metadata.db-wal" || name == "metadata.db-shm"),
+            "unexpected new files: {new_files:?}"
+        );
+    }
+
     fn test_book(title: &str, authors: Vec<&str>) -> libcalibre::BookAdd {
         libcalibre::BookAdd {
             title: title.to_string(),

--- a/src-tauri/src/libs/calibre/query.rs
+++ b/src-tauri/src/libs/calibre/query.rs
@@ -10,6 +10,7 @@ use crate::libs::file_formats;
 use crate::{book::LibraryBook, state::CitadelState};
 
 use super::custom_columns::{BookCustomValue, CustomColumnDef, CustomValueDto};
+use super::onboarding::{self, DetectedLibrary, SyncStatus};
 use super::ImportableFile;
 
 #[tauri::command]
@@ -290,4 +291,128 @@ pub fn clb_query_get_custom_values_for_book(
 pub fn clb_query_is_path_valid_library(library_root: String) -> bool {
     let db_path = libcalibre::util::get_db_path(&library_root);
     db_path.is_some()
+}
+
+/// Find an existing Calibre library for first-run onboarding: Calibre's own
+/// config (`global.py.json`) first, then the default `~/Calibre Library`
+/// folder. `None` means nothing detected — never an error.
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_detect_calibre_library(handle: tauri::AppHandle) -> Option<DetectedLibrary> {
+    use tauri::Manager;
+
+    let home = handle.path().home_dir().ok()?;
+    onboarding::detect_calibre_library(&home)
+}
+
+/// Headline counts for the post-open reveal. i64 mirrors SQLite's COUNT;
+/// exported to TS as `number` (see the bigint exporter setting in main.rs).
+#[derive(Serialize, Deserialize, specta::Type, Clone, Copy, Debug)]
+pub struct LibraryStats {
+    pub book_count: i64,
+    pub author_count: i64,
+}
+
+/// Read-only peek at the library under `library_root`, without touching the
+/// app's active library state — safe to call on a path the user has merely
+/// pointed at.
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_library_stats(library_root: String) -> Result<LibraryStats, String> {
+    let db_path = libcalibre::util::get_db_path(&library_root)
+        .ok_or_else(|| format!("No Calibre library at '{library_root}'"))?;
+    let stats = libcalibre::library_stats(&db_path).map_err(|e| e.to_string())?;
+    Ok(LibraryStats {
+        book_count: stats.book_count,
+        author_count: stats.author_count,
+    })
+}
+
+/// Best-effort cloud-sync detection for a candidate library path, backing the
+/// warn-don't-block onboarding UX. Unknown providers report unsynced.
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_path_sync_status(path: String) -> SyncStatus {
+    onboarding::path_sync_status(Path::new(&path))
+}
+
+/// Suggested folder for a brand-new library (`~/Citadel`). Resolved only —
+/// nothing is created until `clb_cmd_create_library`.
+#[tauri::command]
+#[specta::specta]
+pub fn clb_query_default_new_library_path(handle: tauri::AppHandle) -> Result<String, String> {
+    use tauri::Manager;
+
+    let home = handle
+        .path()
+        .home_dir()
+        .map_err(|e| format!("Cannot resolve home directory: {e}"))?;
+    Ok(onboarding::default_new_library_path(&home))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The same artifact `clb_cmd_create_library` extracts, so the stats peek
+    /// is tested against a real freshly-created library.
+    fn extract_empty_library(target: &Path) {
+        let zip_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("resources/empty_7_2_calibre_lib.zip");
+        let file = std::fs::File::open(zip_path).unwrap();
+        let mut archive = zip::ZipArchive::new(file).unwrap();
+        archive.extract(target).unwrap();
+    }
+
+    #[test]
+    fn library_stats_on_fresh_library_are_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        extract_empty_library(tmp.path());
+
+        let stats = clb_query_library_stats(tmp.path().to_string_lossy().into_owned()).unwrap();
+        assert_eq!(stats.book_count, 0);
+        assert_eq!(stats.author_count, 0);
+    }
+
+    #[test]
+    fn library_stats_count_books_and_distinct_authors() {
+        let tmp = tempfile::tempdir().unwrap();
+        extract_empty_library(tmp.path());
+
+        let library_root = tmp.path().to_string_lossy().into_owned();
+        let db_path = libcalibre::util::get_db_path(&library_root).unwrap();
+        let mut lib = libcalibre::Library::new(db_path).unwrap();
+        lib.add_book(test_book("Book One", vec!["Ann Author"]))
+            .unwrap();
+        lib.add_book(test_book("Book Two", vec!["Ann Author", "Bob Writer"]))
+            .unwrap();
+
+        let stats = clb_query_library_stats(library_root).unwrap();
+        assert_eq!(stats.book_count, 2);
+        assert_eq!(stats.author_count, 2);
+    }
+
+    #[test]
+    fn library_stats_error_on_non_library_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = clb_query_library_stats(tmp.path().to_string_lossy().into_owned());
+        assert!(result.is_err());
+    }
+
+    fn test_book(title: &str, authors: Vec<&str>) -> libcalibre::BookAdd {
+        libcalibre::BookAdd {
+            title: title.to_string(),
+            author_names: authors.into_iter().map(String::from).collect(),
+            tags: None,
+            series: None,
+            series_index: None,
+            publisher: None,
+            publication_date: None,
+            rating: None,
+            comments: None,
+            identifiers: std::collections::HashMap::new(),
+            language: None,
+            file_paths: Vec::new(),
+        }
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,6 +24,11 @@ fn run_tauri_backend() -> std::io::Result<()> {
         calibre::init_client,
         calibre::query::clb_query_is_path_valid_library,
         calibre::command::clb_cmd_create_library,
+        // First-run onboarding: detection-led library setup (CDL-19)
+        calibre::query::clb_query_detect_calibre_library,
+        calibre::query::clb_query_library_stats,
+        calibre::query::clb_query_path_sync_status,
+        calibre::query::clb_query_default_new_library_path,
         // Book query commands
         calibre::query::clb_query_search_books,
         calibre::query::clb_query_books,
@@ -65,7 +70,12 @@ fn run_tauri_backend() -> std::io::Result<()> {
 
     #[cfg(debug_assertions)] // <- Only export on non-release builds
     builder
-        .export(Typescript::default(), "../src/bindings.ts")
+        .export(
+            // i64 fields (LibraryStats counts) export as `number`; fine for
+            // values far below 2^53, which library counts always are.
+            Typescript::default().bigint(specta_typescript::BigIntExportBehavior::Number),
+            "../src/bindings.ts",
+        )
         .expect("Failed to export typescript bindings");
 
     let mut tauri_builder = tauri::Builder::default();

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -24,6 +24,46 @@ async clbCmdCreateLibrary(libraryRoot: string) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Find an existing Calibre library for first-run onboarding: Calibre's own
+ * config (`global.py.json`) first, then the default `~/Calibre Library`
+ * folder. `None` means nothing detected — never an error.
+ */
+async clbQueryDetectCalibreLibrary() : Promise<DetectedLibrary | null> {
+    return await TAURI_INVOKE("clb_query_detect_calibre_library");
+},
+/**
+ * Read-only peek at the library under `library_root`, without touching the
+ * app's active library state — safe to call on a path the user has merely
+ * pointed at.
+ */
+async clbQueryLibraryStats(libraryRoot: string) : Promise<Result<LibraryStats, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_library_stats", { libraryRoot }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Best-effort cloud-sync detection for a candidate library path, backing the
+ * warn-don't-block onboarding UX. Unknown providers report unsynced.
+ */
+async clbQueryPathSyncStatus(path: string) : Promise<SyncStatus> {
+    return await TAURI_INVOKE("clb_query_path_sync_status", { path });
+},
+/**
+ * Suggested folder for a brand-new library (`~/Citadel`). Resolved only —
+ * nothing is created until `clb_cmd_create_library`.
+ */
+async clbQueryDefaultNewLibraryPath() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("clb_query_default_new_library_path") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clbQuerySearchBooks(query: string) : Promise<Result<LibraryBook[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clb_query_search_books", { query }) };
@@ -349,6 +389,19 @@ export type CustomValueDto = { Bool: boolean } | { Int: number } | { Float: numb
  * RFC3339 datetime string, e.g. `2024-01-15T10:30:00+00:00`.
  */
 { Datetime: string } | { Enumeration: string }
+export type DetectedLibrary = { path: string; source: DetectionSource }
+/**
+ * Where [`detect_calibre_library`] found its hit.
+ */
+export type DetectionSource = 
+/**
+ * `library_path` in Calibre's own `global.py.json`.
+ */
+"calibre-config" | 
+/**
+ * Calibre's default `~/Calibre Library` folder.
+ */
+"default-folder"
 /**
  * Book identifiers, such as ISBN, DOI, Google Books ID, etc.
  */
@@ -411,6 +464,11 @@ limit: number | null; offset: number }
  */
 export type LibrarySeries = { id: number; name: string; book_count: number }
 /**
+ * Headline counts for the post-open reveal. i64 mirrors SQLite's COUNT;
+ * exported to TS as `number` (see the bigint exporter setting in main.rs).
+ */
+export type LibraryStats = { book_count: number; author_count: number }
+/**
  * One tag in the library; `name` is what the tag autocomplete suggests.
  */
 export type LibraryTag = { id: number; name: string }
@@ -434,6 +492,12 @@ export type MetadataProvider = "hardcover" | "loc" | "dnb" | "k10plus" | "openli
 export type NewAuthor = { name: string; sortable_name: string | null }
 export type ProviderStatus = { provider: MetadataProvider; is_valid: boolean; message: string }
 export type RemoteFile = { url: string }
+/**
+ * Best-effort cloud-sync verdict for a candidate library path. Informational
+ * only — the UX warns, it never blocks. Unknown providers (Seafile, Syncthing,
+ * …) report `synced: false`.
+ */
+export type SyncStatus = { synced: boolean; provider: string | null }
 export type UpdateCheckResult = { has_update: boolean; version: string | null }
 
 /** tauri-specta globals **/


### PR DESCRIPTION
Backend surface for detection-led library setup, ahead of the onboarding UI slice.

Part of CDL-19

## Surface

- `clb_query_detect_calibre_library` — finds an existing Calibre library: `library_path` from Calibre's own `global.py.json` first (per-OS config resolution, XDG-aware), falling back to `~/Calibre Library`. Candidates must actually hold a `metadata.db`. Malformed/missing config never errors — detection returns `None` or falls through.
- `clb_query_library_stats` — read-only book/author counts for a library the user has merely pointed at. Opens its own connection with `PRAGMA query_only = ON` (never `establish_connection`, which would persistently flip the db to WAL and re-register triggers). Never modifies the database file.
- `clb_query_path_sync_status` — best-effort iCloud/Dropbox/OneDrive/Google Drive detection (path components, `~/Library/CloudStorage` File Provider roots, Dropbox marker files). Unknown providers report unsynced; warn-don't-block.
- `clb_query_default_new_library_path` — suggests `~/Citadel`; nothing is created until the user confirms.
- `clb_cmd_create_library` now refuses non-empty targets with exact error codes the frontend can branch on: `create-library/folder-not-empty` and `create-library/already-a-library` (OS junk files like `.DS_Store` don't count).
- Regenerated `src/bindings.ts` (specta; `bigint → number` exporter for the i64 counts — no pre-existing types affected).

## Validation (independent Bosun pass)

- `cargo test --workspace`: 19 targets, 264 passed, 0 failed (30 new tests, real fixtures throughout).
- `bun lint` exit 0 (13 pre-existing clippy warnings, none in new code); `bun format` no diff; `bun run build:web` green.
- Error-code strings, bindings field order/names, and detection failure paths verified against the contract.
- Read-only claim verified empirically: journal-mode libraries (all Calibre-managed ones) stay byte-clean after a stats call. WAL-mode libraries (only ones Citadel itself opened before) gain at most the `-wal`/`-shm` sidecars, which persist on macOS for **every** connection app-wide — Apple's system SQLite ships `SQLITE_FCNTL_PERSIST_WAL` on by default, so no connection-level remedy exists. That platform fact is now pinned by regression tests and documented in `stats.rs` + `AGENTS.md`.
- Live-app TCC check (crew): zero `com.apple.TCC` events reading `~/Library/Preferences/calibre/global.py.json`; finding recorded in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)